### PR TITLE
upgraded go-git to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.gitea.io/sdk/gitea v0.14.0 // indirect
 	gitea.com/gitea/go-sdk v0.0.0-20210527220201-42fed7165c7a // indirect
 	github.com/alecthomas/kong v0.2.16
-	github.com/go-git/go-git/v5 v5.4.1 // indirect
+	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/gogs/git-module v1.1.5 // indirect
 	github.com/gogs/go-gogs-client v0.0.0-20210131175652-1d7215cd8d85 // indirect
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.1 h1:2RJXJuTMac944e419pJJJ3mOJBcr3A3M6SN6wQKZ/Gs=
 github.com/go-git/go-git/v5 v5.4.1/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
+github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/gogs/git-module v1.1.5 h1:PIVEGKW3rPbzP6CWrlPk6qol/3WKpoEOWeRd2itrnvo=
 github.com/gogs/git-module v1.1.5/go.mod h1:oN37FFStFjdnTJXsSbhIHKJXh2YeDsEcXPATVz/oeuQ=
 github.com/gogs/go-gogs-client v0.0.0-20210131175652-1d7215cd8d85 h1:UjoPNDAQ5JPCjlxoJd6K8ALZqSDDhk2ymieAZOVaDg0=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,10 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/alecthomas/kong"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/gogs/go-gogs-client"
 	"github.com/google/go-github/github"
 	"github.com/gookit/color"
@@ -19,10 +23,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
v4:
go run . bla.conf  2439,33s user 68,36s system 146% cpu 28:33,65 total

v5:
go run . bla.conf  1883,21s user 55,70s system 145% cpu 22:11,12 total

I could improve the speed through upgrading go-git. As a test I cloned all repositories from geerlingguy