### PR TITLE
Adds archive format override for Windows to use ZIP

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,3 +18,10 @@ builds:
         goarch: 386
       - goos: windows
         goarch: arm
+
+archives:
+  -
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip


### PR DESCRIPTION
This is based on the [Hugo goreleaser][1] configuration. I'm not sure how best to test this, so I'm kinda making an educated stab.

[1]: https://github.com/gohugoio/hugo/blob/master/goreleaser.yml