### PR TITLE
Extracts tilde-in-home check and tests it

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTildeReplacement_NoAction(t *testing.T) {
+	path := "/boop"
+	if SubstituteHomeForTildeInPath(path) != path {
+		t.Error("Altered path when no alteration was expected")
+	}
+}
+
+func TestTildeReplacement_TildeOnly(t *testing.T) {
+	path := "~"
+	if SubstituteHomeForTildeInPath(path) == path {
+		t.Error("Path unaltered when alteration was expected")
+	}
+}
+
+func TestTildeReplacement_TildeDir(t *testing.T) {
+	path := "~/boop"
+	actual := SubstituteHomeForTildeInPath(path)
+	if strings.HasPrefix(actual, "~") {
+		t.Error("Altered path still contains ~")
+	}
+
+	if !strings.HasSuffix(actual, "boop") {
+		t.Error("Altered path does not end with directory to be retained")
+	}
+}


### PR DESCRIPTION
This started because `user.Current()` errors inside the container for reasons I don't understand, but it doesn't matter to me because the local destination inside the container is not `~` or something beginning with `~/`. So, skip that check except when it's needed. Then I refactored some more and added a test.