### PR TITLE
Adds tzdata to enable setting time zone in cron specifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine as builder
 
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates tzdata
 
 WORKDIR /go/src/github.com/cooperspencer/gickup
 COPY . .
@@ -12,4 +12,5 @@ FROM scratch as production
 WORKDIR /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/cooperspencer/gickup/app /gickup/app
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 CMD ["./gickup/app"]


### PR DESCRIPTION
This enables setting the timezone in the cron specifier, e.g.

```yaml
cron: TZ=America/New_York 0 2 * * *
```

Without this package's data, you'll get an error:

```
2021-12-17 04:08:35 ERR provided bad location America/New_York: unknown
time zone America/New_York spec="TZ=America/New_York 0 2 * * *"
```

Warning: I don't have Docker installed on the machine I did this one but this is one of those "yeah, looks right, let CI yell if I'm wrong" things.