### PR TITLE
Extract methods for local repo clone and update

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -62,87 +62,110 @@ func Locally(repo types.Repo, l types.Local, dry bool) {
 		if os.IsNotExist(err) {
 			log.Info().Str("stage", "locally").Str("path", l.Path).Msgf("cloning %s", types.Green(repo.Name))
 
-			if !dry {
-				url := repo.Url
-				if repo.Origin.SSH {
-					url = repo.SshUrl
-					site := types.Site{}
-					err := site.GetValues(url)
-					if err != nil {
-						log.Fatal().Str("stage", "locally").Msg(err.Error())
-					}
-					auth, err := goph.Key(repo.Origin.SSHKey, "")
-					if err != nil {
-						log.Fatal().Str("stage", "locally").Msg(err.Error())
-					}
-					_, err = goph.NewConn(&goph.Config{
-						User:     site.User,
-						Addr:     site.Url,
-						Port:     uint(site.Port),
-						Auth:     auth,
-						Callback: VerifyHost,
-					})
-					if err != nil {
-						log.Fatal().Str("stage", "locally").Msg(err.Error())
-					}
-				}
+			err := cloneRepository(repo, auth, dry)
 
-				_, err = git.PlainClone(repo.Name, false, &git.CloneOptions{
-					URL:          url,
-					Auth:         auth,
-					SingleBranch: false,
-				})
-
-				if err != nil {
-					if x == tries {
-						log.Fatal().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
-					} else {
-						if strings.Contains(err.Error(), "remote repository is empty") {
-							log.Warn().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
-							break
-						}
-						log.Warn().Str("stage", "locally").Str("path", l.Path).Msgf("retry %s from %s", types.Red(x), types.Red(tries))
-						time.Sleep(5 * time.Second)
-						continue
+			if err != nil {
+				if x == tries {
+					log.Fatal().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
+				} else {
+					if strings.Contains(err.Error(), "remote repository is empty") {
+						log.Warn().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
+						break
 					}
+					log.Warn().Str("stage", "locally").Str("path", l.Path).Msgf("retry %s from %s", types.Red(x), types.Red(tries))
+					time.Sleep(5 * time.Second)
+					continue
 				}
 			}
 		} else {
-			if stat.IsDir() {
+			if !stat.IsDir() {
+				log.Warn().Str("stage", "locally").Str("path", l.Path).Msgf("%s is a file", types.Red(repo.Name))
+			} else {
 				log.Info().Str("stage", "locally").Str("path", l.Path).Msgf("opening %s locally", types.Green(repo.Name))
-				r, err := git.PlainOpen(repo.Name)
-				if err != nil {
-					log.Fatal().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
-				}
-				w, err := r.Worktree()
-				if err != nil {
-					log.Fatal().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
-				}
 
-				log.Info().Str("stage", "locally").Str("path", l.Path).Msgf("pulling %s", types.Green(repo.Name))
-				if !dry {
-					err = w.Pull(&git.PullOptions{Auth: auth, RemoteName: "origin", SingleBranch: false})
-					if err != nil {
-						if strings.Contains(err.Error(), "already up-to-date") {
-							log.Info().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
+				err := updateRepository(repo.Name, auth, dry)
+
+				if err != nil {
+					if strings.Contains(err.Error(), "already up-to-date") {
+						log.Info().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
+					} else {
+						if x == tries {
+							log.Fatal().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
 						} else {
-							if x == tries {
-								log.Fatal().Str("stage", "locally").Str("path", l.Path).Msg(err.Error())
-							} else {
-								os.RemoveAll(repo.Name)
-								log.Warn().Str("stage", "locally").Str("path", l.Path).Msgf("retry %s from %s", types.Red(x), types.Red(tries))
-								time.Sleep(5 * time.Second)
-								continue
-							}
+							os.RemoveAll(repo.Name)
+							log.Warn().Str("stage", "locally").Str("path", l.Path).Msgf("retry %s from %s", types.Red(x), types.Red(tries))
+							time.Sleep(5 * time.Second)
+							continue
 						}
 					}
 				}
-			} else {
-				log.Warn().Str("stage", "locally").Str("path", l.Path).Msgf("%s is a file", types.Red(repo.Name))
 			}
 		}
 		x = 5
 	}
+}
+
+func updateRepository(repoPath string, auth transport.AuthMethod, dry bool) error {
+	r, err := git.PlainOpen(repoPath)
+	if err != nil {
+		return err
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+
+	if !dry {
+		log.Info().Str("stage", "locally").Msgf("pulling %s", types.Green(repoPath))
+		err = w.Pull(&git.PullOptions{Auth: auth, RemoteName: "origin", SingleBranch: false})
+	}
+	return err
+}
+
+func cloneRepository(repo types.Repo, auth transport.AuthMethod, dry bool) error {
+	if !dry {
+		url := repo.Url
+		if repo.Origin.SSH {
+			url = repo.SshUrl
+			site := types.Site{}
+			err := site.GetValues(url)
+			if err != nil {
+				log.Fatal().Str("stage", "locally").Msg(err.Error())
+			}
+
+			sshAuth, err := goph.Key(repo.Origin.SSHKey, "")
+			if err != nil {
+				log.Fatal().Str("stage", "locally").Msg(err.Error())
+			}
+
+			err = testSshConnection(site, sshAuth)
+			if err != nil {
+				log.Fatal().Str("stage", "locally").Msg(err.Error())
+			}
+		}
+
+		_, err := git.PlainClone(repo.Name, false, &git.CloneOptions{
+			URL:          url,
+			Auth:         auth,
+			SingleBranch: false,
+		})
+
+		return err
+	}
+	return nil
+}
+
+func testSshConnection(site types.Site, sshAuth goph.Auth) error {
+	_, err := goph.NewConn(&goph.Config{
+		User:     site.User,
+		Addr:     site.Url,
+		Port:     uint(site.Port),
+		Auth:     sshAuth,
+		Callback: VerifyHost,
+	})
+
+	return err
 }
 
 func VerifyHost(host string, remote net.Addr, key gossh.PublicKey) error {


### PR DESCRIPTION
It was a little difficult to understand what was going where, esp. with Go's verbose logging, so I extracted methods where appropriate. This should also ease some testing concerns down the road.

As I said in #62, I thought I might pull this in its own PR. Yeah, it's worth a separate conversation, methinks.

No new tests, but I ran it against my export and it worked fine seemingly.