### PR TITLE
Fix typo and grammatical errors in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can clone/mirror them to:
 - Gogs
 - Local
 
-## How to make an Configuration file?
+## How to make a Configuration file?
 [Here is an example](https://github.com/cooperspencer/gickup/blob/main/conf.example.yml)
 
 ## How to run the Binary version

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ You can clone/mirror them to:
 - Gogs
 - Local
 
-## How to make a Configuration file?
+## How to make a configuration file
 [Here is an example](https://github.com/cooperspencer/gickup/blob/main/conf.example.yml)
 
-## How to run the Binary version
+## How to run the binary version
 `./gickup path-to-conf.yml`
 
 ## How to run the Docker image
@@ -26,7 +26,7 @@ wget https://raw.githubusercontent.com/cooperspencer/gickup/main/docker-compose.
 nano conf.yml # Make your config here
 docker-compose up
 ```
-## Compile the Binary version
+## Compile the binary version
 `go build .`
 
 ## Compile the Docker Image


### PR DESCRIPTION
Because `Configuration` does not start with a vowel sound, `a` is the correct determiner to use instead of `an`. I also noticed that words like `Configuration` and `Binary` should not be capitalized, since they are not proper nouns. I removed the question mark from `How to make an Configuration file?` because it is a statement, not a question.

I have loved using gickup over the past week. Thank you for making it!

I was disappointed that I couldn't contribute, since I don't know Go, but then I realized I _could_ be of some help (albeit small) when I saw a couple of grammatical improvements in your `README.md` that could be made. I hope this helps!