### PR TITLE
Add excludeorgs for gitlab.

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -118,6 +118,7 @@ func Get(conf *types.Conf) []types.Repo {
 
 		include := types.GetMap(repo.Include)
 		exclude := types.GetMap(repo.Exclude)
+		excludeorgs := types.GetMap(repo.ExcludeOrgs)
 
 		for _, r := range gitlabrepos {
 			if include[r.Name] {
@@ -208,6 +209,9 @@ func Get(conf *types.Conf) []types.Repo {
 						continue
 					}
 					if exclude[r.Name] {
+						continue
+					}
+					if excludeorgs[r.Namespace.FullPath] {
 						continue
 					}
 					if len(include) == 0 {

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -117,6 +117,7 @@ func Get(conf *types.Conf) []types.Repo {
 		}
 
 		include := types.GetMap(repo.Include)
+		includeorgs := types.GetMap(repo.IncludeOrgs)
 		exclude := types.GetMap(repo.Exclude)
 		excludeorgs := types.GetMap(repo.ExcludeOrgs)
 
@@ -215,17 +216,19 @@ func Get(conf *types.Conf) []types.Repo {
 						continue
 					}
 					if len(include) == 0 {
-						if r.RepositoryAccessLevel != gitlab.DisabledAccessControl {
-							repos = append(repos, types.Repo{Name: r.Path, Url: r.HTTPURLToRepo, SshUrl: r.SSHURLToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: k, Hoster: types.GetHost(repo.Url)})
-						}
-
-						if r.WikiEnabled && repo.Wiki {
-							if activeWiki(r, client, repo) {
-								httpUrlToRepo := types.DotGitRx.ReplaceAllString(r.HTTPURLToRepo, ".wiki.git")
-								sshUrlToRepo := types.DotGitRx.ReplaceAllString(r.SSHURLToRepo, ".wiki.git")
-								repos = append(repos, types.Repo{Name: r.Path + ".wiki", Url: httpUrlToRepo, SshUrl: sshUrlToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: k, Hoster: types.GetHost(repo.Url)})
+						if len(includeorgs) == 0 || includeorgs[r.Namespace.FullPath] {
+							if r.RepositoryAccessLevel != gitlab.DisabledAccessControl {
+								repos = append(repos, types.Repo{Name: r.Path, Url: r.HTTPURLToRepo, SshUrl: r.SSHURLToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: k, Hoster: types.GetHost(repo.Url)})
 							}
-						}
+
+							if r.WikiEnabled && repo.Wiki {
+								if activeWiki(r, client, repo) {
+									httpUrlToRepo := types.DotGitRx.ReplaceAllString(r.HTTPURLToRepo, ".wiki.git")
+									sshUrlToRepo := types.DotGitRx.ReplaceAllString(r.SSHURLToRepo, ".wiki.git")
+									repos = append(repos, types.Repo{Name: r.Path + ".wiki", Url: httpUrlToRepo, SshUrl: sshUrlToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: k, Hoster: types.GetHost(repo.Url)})
+								}
+							}
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
Gitlab does not explicitly have orgs but they do have Namespaces which
are roughly equivalent.

Signed-off-by: Drew Moseley <drew@moseleynet.net>