### PR TITLE
fix: stat github wiki remotes to verify their existence

### DIFF
--- a/gitea/gitea.go
+++ b/gitea/gitea.go
@@ -95,7 +95,7 @@ func Get(conf *types.Conf) []types.Repo {
 		for _, r := range gitearepos {
 			if include[r.Name] {
 				repos = append(repos, types.Repo{Name: r.Name, Url: r.CloneURL, SshUrl: r.SSHURL, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
-				if r.HasWiki && repo.Wiki {
+				if r.HasWiki && repo.Wiki && types.StatRemote(r.CloneURL, r.SSHURL, repo) {
 					repos = append(repos, types.Repo{Name: r.Name + ".wiki", Url: types.DotGitRx.ReplaceAllString(r.CloneURL, ".wiki.git"), SshUrl: types.DotGitRx.ReplaceAllString(r.SSHURL, ".wiki.git"), Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
 				}
 				continue
@@ -105,7 +105,7 @@ func Get(conf *types.Conf) []types.Repo {
 			}
 			if len(repo.Include) == 0 {
 				repos = append(repos, types.Repo{Name: r.Name, Url: r.CloneURL, SshUrl: r.SSHURL, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
-				if r.HasWiki && repo.Wiki {
+				if r.HasWiki && repo.Wiki && types.StatRemote(r.CloneURL, r.SSHURL, repo) {
 					repos = append(repos, types.Repo{Name: r.Name + ".wiki", Url: types.DotGitRx.ReplaceAllString(r.CloneURL, ".wiki.git"), SshUrl: types.DotGitRx.ReplaceAllString(r.SSHURL, ".wiki.git"), Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
 				}
 			}
@@ -152,7 +152,7 @@ func Get(conf *types.Conf) []types.Repo {
 		for _, r := range orgrepos {
 			if include[r.Name] {
 				repos = append(repos, types.Repo{Name: r.Name, Url: r.CloneURL, SshUrl: r.SSHURL, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
-				if r.HasWiki && repo.Wiki {
+				if r.HasWiki && repo.Wiki && types.StatRemote(r.CloneURL, r.SSHURL, repo) {
 					repos = append(repos, types.Repo{Name: r.Name + ".wiki", Url: types.DotGitRx.ReplaceAllString(r.CloneURL, ".wiki.git"), SshUrl: types.DotGitRx.ReplaceAllString(r.SSHURL, ".wiki.git"), Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
 				}
 				continue
@@ -162,7 +162,7 @@ func Get(conf *types.Conf) []types.Repo {
 			}
 			if len(repo.Include) == 0 {
 				repos = append(repos, types.Repo{Name: r.Name, Url: r.CloneURL, SshUrl: r.SSHURL, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
-				if r.HasWiki && repo.Wiki {
+				if r.HasWiki && repo.Wiki && types.StatRemote(r.CloneURL, r.SSHURL, repo) {
 					repos = append(repos, types.Repo{Name: r.Name + ".wiki", Url: types.DotGitRx.ReplaceAllString(r.CloneURL, ".wiki.git"), SshUrl: types.DotGitRx.ReplaceAllString(r.SSHURL, ".wiki.git"), Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.UserName, Hoster: types.GetHost(repo.Url)})
 				}
 			}

--- a/github/github.go
+++ b/github/github.go
@@ -9,7 +9,7 @@ import (
 )
 
 func addWiki(r github.Repository, repo types.GenRepo, token string) types.Repo {
-	if r.GetHasWiki() && repo.Wiki && r.GetHasPages() {
+	if r.GetHasWiki() && repo.Wiki && types.StatRemote(r.GetCloneURL(), r.GetSSHURL(), repo) {
 		return types.Repo{Name: *r.Name + ".wiki", Url: types.DotGitRx.ReplaceAllString(r.GetCloneURL(), ".wiki.git"), SshUrl: types.DotGitRx.ReplaceAllString(r.GetSSHURL(), ".wiki.git"), Token: token, Defaultbranch: r.GetDefaultBranch(), Origin: repo, Owner: r.GetOwner().GetLogin(), Hoster: "github.com"}
 	}
 	return types.Repo{}


### PR DESCRIPTION
As far as I can tell, the `HasPages` property for GitHub repositories doesn't indicate whether their wiki contains pages, it indicates whether [GitHub Pages](https://pages.github.com/) is enabled (though it's difficult to tell because I can't find documentation anywhere). I can't find any way to check whether the wiki is populated via the API. This fix verifies that the wiki exists by attempting to connect to it and listing the available refs. This does have a performance impact since (as #78 metions) wikis are enabled by default, so we have to attempt to list refs in almost all wikis, it doesn't take too long though. The auth code is copied from the local module's `cloneRepository` function.

We may be able to do the same thing for Gitea if this is an acceptable solution.