### PR TITLE
fix: use gitlab namespace path instead of owner

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -101,14 +101,14 @@ func Get(conf *types.Conf) []types.Repo {
 		for _, r := range gitlabrepos {
 			if include[r.Name] {
 				if r.RepositoryAccessLevel != gitlab.DisabledAccessControl {
-					repos = append(repos, types.Repo{Name: r.Path, Url: r.HTTPURLToRepo, SshUrl: r.SSHURLToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.Username, Hoster: types.GetHost(repo.Url)})
+					repos = append(repos, types.Repo{Name: r.Path, Url: r.HTTPURLToRepo, SshUrl: r.SSHURLToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Namespace.FullPath, Hoster: types.GetHost(repo.Url)})
 				}
 
 				if r.WikiEnabled && repo.Wiki {
 					if activeWiki(r, client, repo) {
 						httpUrlToRepo := types.DotGitRx.ReplaceAllString(r.HTTPURLToRepo, ".wiki.git")
 						sshUrlToRepo := types.DotGitRx.ReplaceAllString(r.SSHURLToRepo, ".wiki.git")
-						repos = append(repos, types.Repo{Name: r.Path + ".wiki", Url: httpUrlToRepo, SshUrl: sshUrlToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.Username, Hoster: types.GetHost(repo.Url)})
+						repos = append(repos, types.Repo{Name: r.Path + ".wiki", Url: httpUrlToRepo, SshUrl: sshUrlToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Namespace.FullPath, Hoster: types.GetHost(repo.Url)})
 					}
 				}
 
@@ -119,14 +119,14 @@ func Get(conf *types.Conf) []types.Repo {
 			}
 			if len(include) == 0 {
 				if r.RepositoryAccessLevel != gitlab.DisabledAccessControl {
-					repos = append(repos, types.Repo{Name: r.Path, Url: r.HTTPURLToRepo, SshUrl: r.SSHURLToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.Username, Hoster: types.GetHost(repo.Url)})
+					repos = append(repos, types.Repo{Name: r.Path, Url: r.HTTPURLToRepo, SshUrl: r.SSHURLToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Namespace.FullPath, Hoster: types.GetHost(repo.Url)})
 				}
 
 				if r.WikiEnabled && repo.Wiki {
 					if activeWiki(r, client, repo) {
 						httpUrlToRepo := types.DotGitRx.ReplaceAllString(r.HTTPURLToRepo, ".wiki.git")
 						sshUrlToRepo := types.DotGitRx.ReplaceAllString(r.SSHURLToRepo, ".wiki.git")
-						repos = append(repos, types.Repo{Name: r.Path + ".wiki", Url: httpUrlToRepo, SshUrl: sshUrlToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Owner.Username, Hoster: types.GetHost(repo.Url)})
+						repos = append(repos, types.Repo{Name: r.Path + ".wiki", Url: httpUrlToRepo, SshUrl: sshUrlToRepo, Token: token, Defaultbranch: r.DefaultBranch, Origin: repo, Owner: r.Namespace.FullPath, Hoster: types.GetHost(repo.Url)})
 					}
 				}
 			}


### PR DESCRIPTION
When authenticating with GitLab via SSH, I get the following error:

```
2022-02-25T18:25:54-05:00 INF grabbing repositories from mtoohey stage=gitlab url=https://gitlab.com
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x8d99da]

goroutine 1 [running]:
gickup/gitlab.Get(0xc0001746e0)
	/home/mtoohey/repos/gickup/gitlab/gitlab.go:145 +0x10fa
main.RunBackup(0xc0001746e0)
	/home/mtoohey/repos/gickup/main.go:148 +0x285
main.main()
	/home/mtoohey/repos/gickup/main.go:234 +0xb15
exit status 2
```

According to the [GitLab API docs](https://docs.gitlab.com/ee/api/projects.html), it seems that `Namespace.FullPath` should always be present, so this PR switches to using that, because `Owner.Username` doesn't seem to be available over SSH. I've tested this with SSH and token authentication.