### PR TITLE
feat: add heartbeat metrics

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -153,3 +153,5 @@ metrics:
   prometheus:
     endpoint: /metrics
     listen_addr: ":6178" # default listens on port 6178 on all IPs.
+  heartbeat:
+    url: http(s)://url-to-make-request-to

--- a/metrics/heartbeat/heartbeat.go
+++ b/metrics/heartbeat/heartbeat.go
@@ -1,0 +1,16 @@
+package heartbeat
+
+import (
+	"net/http"
+
+	"gickup/types"
+	"github.com/rs/zerolog/log"
+)
+
+func Send(conf types.HeartbeatConfig) {
+	log.Info().Str("url", conf.URL).Msg("sending heartbeat")
+	_, err := http.Get(conf.URL)
+	if err != nil {
+		log.Fatal().Str("monitoring", "heartbeat").Msg(err.Error())
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -50,8 +50,13 @@ type PrometheusConfig struct {
 	Endpoint   string `yaml:"endpoint"`
 }
 
+type HeartbeatConfig struct {
+	URL string `yaml:"url"`
+}
+
 type Metrics struct {
 	Prometheus PrometheusConfig `yaml:"prometheus"`
+	Heartbeat  HeartbeatConfig  `yaml:"heartbeat"`
 }
 
 type Logging struct {


### PR DESCRIPTION
Prometheus is a bit overkill for my use case, so I was wondering if you'd be interested in adding a more simple metrics option. Basically, if the user provides a non-empty URL, gickup makes a `GET` request to the URL after each backup. I totally understand if this seems like an unecessary feature though. Similar functionality can already be accomplished by using your own scheduling method and making the request with CURL if gickup exited successfully, though this feels kind of hacky too since scheduling is already built-in.

If you're interested in adding this feature, I had one implementation question: should I make the config section a mapping with a `url` key so we can expand it without breaking changes if neccessary (though I can't think of how we'd need to), or should I just make `heartbeat` a string that takes the url?