### PR TITLE
chore: update builder stage of Dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM golang:alpine as builder
+FROM golang:1.17-alpine as builder
 
 # Install dependencies for copy
-RUN apk add -U --no-cache ca-certificates tzdata
+RUN apk add -U --no-cache ca-certificates tzdata git
 
 # Use an valid GOPATH and copy the files
 WORKDIR /go/src/github.com/cooperspencer/gickup
+
+# Pre fetching dependancies to take advantage of the docker caching system
+COPY go.mod .
+COPY go.sum .
+RUN go mod tidy
+
 COPY . .
 
 # Fetching dependencies and build the app


### PR DESCRIPTION
Following discussion on #101, this PR adds a few things in the builder stage of the Dockerfile.
It adds the `git` program, as well as utilizing the docker cache feature when building, and a fixed version of the Golang base image.