### PR TITLE
 feat: Support multiple heartbeat URLs

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -153,3 +153,5 @@ metrics:
   prometheus:
     endpoint: /metrics
     listen_addr: ":6178" # default listens on port 6178 on all IPs.
+  heartbeat:
+    url: http(s)://url-to-make-request-to

--- a/conf.example.yml
+++ b/conf.example.yml
@@ -150,8 +150,10 @@ log: # optional
     maxage: 7 # keep logs for 7 days
 
 metrics:
-  prometheus:
+  prometheus: # optional
     endpoint: /metrics
     listen_addr: ":6178" # default listens on port 6178 on all IPs.
-  heartbeat:
-    url: http(s)://url-to-make-request-to
+  heartbeat: # optional - upon successful backup, makes a GET http request to one or more URLs. This is useful for use with monitoring services such as healthchecks.io or deadmanssnitch.com
+    urls:
+      - http(s)://url-to-make-request-to
+      - http(s)://another-url-to-make-request-to

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func runBackup(conf *types.Conf) {
 	prometheus.JobsComplete.Inc()
 	prometheus.JobDuration.Observe(duration.Seconds())
 
-	if conf.Metrics.Heartbeat.URL != "" {
+	if len(conf.Metrics.Heartbeat.URLs) > 0 {
 		heartbeat.Send(conf.Metrics.Heartbeat)
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cooperspencer/gickup/gogs"
 	"github.com/cooperspencer/gickup/local"
 	"github.com/cooperspencer/gickup/logger"
+	"github.com/cooperspencer/gickup/metrics/heartbeat"
 	"github.com/cooperspencer/gickup/metrics/prometheus"
 	"github.com/cooperspencer/gickup/types"
 	"github.com/robfig/cron/v3"
@@ -182,6 +183,10 @@ func runBackup(conf *types.Conf) {
 
 	prometheus.JobsComplete.Inc()
 	prometheus.JobDuration.Observe(duration.Seconds())
+
+	if conf.Metrics.Heartbeat.URL != "" {
+		heartbeat.Send(conf.Metrics.Heartbeat)
+	}
 
 	log.Info().
 		Str("duration", duration.String()).

--- a/metrics/heartbeat/heartbeat.go
+++ b/metrics/heartbeat/heartbeat.go
@@ -12,7 +12,7 @@ func Send(conf types.HeartbeatConfig) {
 		log.Info().Str("url", u).Msg("sending heartbeat")
 		_, err := http.Get(u)
 		if err != nil {
-			log.Fatal().Str("monitoring", "heartbeat").Msg(err.Error())
+			log.Error().Str("monitoring", "heartbeat").Msg(err.Error())
 		}
 	}
 }

--- a/metrics/heartbeat/heartbeat.go
+++ b/metrics/heartbeat/heartbeat.go
@@ -1,0 +1,16 @@
+package heartbeat
+
+import (
+	"net/http"
+
+	"github.com/cooperspencer/gickup/types"
+	"github.com/rs/zerolog/log"
+)
+
+func Send(conf types.HeartbeatConfig) {
+	log.Info().Str("url", conf.URL).Msg("sending heartbeat")
+	_, err := http.Get(conf.URL)
+	if err != nil {
+		log.Fatal().Str("monitoring", "heartbeat").Msg(err.Error())
+	}
+}

--- a/metrics/heartbeat/heartbeat.go
+++ b/metrics/heartbeat/heartbeat.go
@@ -8,9 +8,11 @@ import (
 )
 
 func Send(conf types.HeartbeatConfig) {
-	log.Info().Str("url", conf.URL).Msg("sending heartbeat")
-	_, err := http.Get(conf.URL)
-	if err != nil {
-		log.Fatal().Str("monitoring", "heartbeat").Msg(err.Error())
+	for _, u := range conf.URLs {
+		log.Info().Str("url", u).Msg("sending heartbeat")
+		_, err := http.Get(u)
+		if err != nil {
+			log.Fatal().Str("monitoring", "heartbeat").Msg(err.Error())
+		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -59,7 +59,7 @@ type PrometheusConfig struct {
 }
 
 type HeartbeatConfig struct {
-	URL string `yaml:"url"`
+	URLs []string `yaml:"urls"`
 }
 
 // Metrics TODO.

--- a/types/types.go
+++ b/types/types.go
@@ -58,9 +58,14 @@ type PrometheusConfig struct {
 	Endpoint   string `yaml:"endpoint"`
 }
 
+type HeartbeatConfig struct {
+	URL string `yaml:"url"`
+}
+
 // Metrics TODO.
 type Metrics struct {
 	Prometheus PrometheusConfig `yaml:"prometheus"`
+	Heartbeat  HeartbeatConfig  `yaml:"heartbeat"`
 }
 
 // Logging TODO.


### PR DESCRIPTION
#100 introduced heartbeat support but only supported one URL. This PR was closed, however I've re-introduced this feature and added support for multiple heartbeat URLs as discussed in the #100 discussion.

I've brought #100 up to speed with the latest main branch, and added support for multiple heartbeat URLs.

This also resolves #108 which is a feature request for the heartbeat feature.