### PR TITLE
Only apply language filter if specified in config.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -153,9 +153,11 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 					}
 				}
 			}
-			if r.Language != nil {
-				if !languages[strings.ToLower(*r.Language)] {
-					continue
+			if len(repo.Filter.Languages) > 0 {
+				if r.Language != nil {
+					if !languages[strings.ToLower(*r.Language)] {
+						continue
+					}
 				}
 			}
 			if *r.StargazersCount < repo.Filter.Stars {


### PR DESCRIPTION
GitHub repos were previously filtered by language even when no language filter was specified in config. This only affected GitHub, the others already check if lang filter exists before filtering.