### PR TITLE
Add Fedora package to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ https://github.com/cooperspencer/gickup/discussions
 |---|---|---|
 |Arch|[gickup](https://aur.archlinux.org/packages/gickup/)|[me](https://github.com/cooperspencer)|
 |Homebrew|[gickup](https://formulae.brew.sh/formula/gickup#default)||
+|Fedora|[gickup](https://copr.fedorainfracloud.org/coprs/frostyx/gickup/)|[FrostyX](https://github.com/FrostyX)|
 
 ## Issues
 The mirroring to Gitlab doesn't work, or at least I can't test it properly because I have no access to a Gitlab EE instance.


### PR DESCRIPTION
Not in the official Fedora repositories yet because we are missing some dependencies.
https://copr.fedorainfracloud.org/coprs/frostyx/gickup/

Installation instructions:

```
sudo dnf copr enable frostyx/gickup
sudo dnf install gickup
```