### PR TITLE
Set zip to maximum compression

### DIFF
--- a/zip/zip.go
+++ b/zip/zip.go
@@ -2,6 +2,7 @@ package zip
 
 import (
 	"archive/zip"
+	"compress/flate"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,9 @@ func Zip(repository string, tozip []string) error {
 	defer file.Close()
 
 	w := zip.NewWriter(file)
+	w.RegisterCompressor(zip.Deflate, func(out io.Writer) (io.WriteCloser, error) {
+		return flate.NewWriter(out, flate.BestCompression)
+	})
 	defer w.Close()
 
 	parentDir := filepath.Dir(repository)


### PR DESCRIPTION
This sets `zip` to use the maximum compression setting.  While it may not save much when backing up a repo *(because its already compressed)*, it will save space when backing up `issues`, `wiki`, etc.

I tested this change on a few repos and this is the conclusion I came to.  Please try it out.
