### PR TITLE
Move production Docker image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,12 @@ COPY . .
 RUN go get -d -v ./...
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o gickup .
 
-# Use scratch as production environment -> Small builds
-FROM scratch as production
+# Use alpine as production environment -> Small builds
+FROM alpine:3.20 as production
+RUN apk add -U --no-cache ca-certificates tzdata git git-lfs
+RUN git lfs install
+
 WORKDIR /
-# Copy valid SSL certs from the builder for fetching github/gitlab/...
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-# Copy zoneinfo for getting the right cron timezone
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 # Copy the main executable from the builder
 COPY --from=builder /go/src/github.com/cooperspencer/gickup/gickup /gickup/gickup
 


### PR DESCRIPTION
Moves the base image to Alpine instead of scratch in the default dockerfile. This allows the install/use of `git-lfs` and resolves #278 (tested/confirmed).

Size comparison (uncompressed):
- Scratch-based image: 27MB
- Alpine-based image: 60MB
- Ubuntu-based image (`:ubuntu-latest`): 270MB