### PR TITLE
fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
         •
         <a href="https://github.com/cooperspencer/gickup/">GitHub</a>
         •
-        <a href="https://cooperspencer.github.io/gickup-documentation/docs/" target="_blank">Docs</a>
+        <a href="https://cooperspencer.github.io/gickup-documentation/" target="_blank">Docs</a>
     </strong>
 </p>
 


### PR DESCRIPTION
The current link redirects to a "page not found" page.

<img width="1052" alt="Screenshot 2024-10-23 at 18 35 53" src="https://github.com/user-attachments/assets/71336d61-3a4e-4060-ac5e-647508c2f575">


Thanks for all your hard work on this tool. It's been really useful to me! 😄 🦾 