### PR TITLE
Add json schema support

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cooperspencer/gickup/refs/heads/main/gickup_spec.json
+
 source:
   github:
     - token: some-token

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -515,34 +515,32 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "properties": {
-                                "endpoint": {
-                                    "type": "string",
-                                    "description": "The endpoint of the S3 server"
-                                },
-                                "structured": {
-                                    "type": "boolean",
-                                    "description": "if set to `true`, it checks out the repos in a more structured way, like `hoster/user|organization/repository`"
-                                },
-                                "bucket": {
-                                    "type": "string",
-                                    "description": "The bucket to store the backups in"
-                                },
-                                "accesskey": {
-                                    "type": "string",
-                                    "description": "The access key to authenticate against the S3 server"
-                                },
-                                "secretkey": {
-                                    "type": "string",
-                                    "description": "The secret key to authenticate against the S3 server"
-                                },
-                                "usessl": {
-                                    "type": "boolean",
-                                    "description": "Use SSL to connect to the S3 server"
-                                }
+                            "endpoint": {
+                                "type": "string",
+                                "description": "The endpoint of the S3 server"
                             },
-                            "additionalProperties": false
-                        }
+                            "structured": {
+                                "type": "boolean",
+                                "description": "if set to `true`, it checks out the repos in a more structured way, like `hoster/user|organization/repository`"
+                            },
+                            "bucket": {
+                                "type": "string",
+                                "description": "The bucket to store the backups in"
+                            },
+                            "accesskey": {
+                                "type": "string",
+                                "description": "The access key to authenticate against the S3 server"
+                            },
+                            "secretkey": {
+                                "type": "string",
+                                "description": "The secret key to authenticate against the S3 server"
+                            },
+                            "usessl": {
+                                "type": "boolean",
+                                "description": "Use SSL to connect to the S3 server"
+                            }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "github": {

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -1,0 +1,866 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "id": "gickup_spec.json",
+    "type": "object",
+    "title": "Gickup configuration spec",
+    "description": "The Gickup configuration spec",
+
+    "properties": {
+
+        "source": {
+            "type": "object",
+            "description": "Configuration for all git hoster source endpoints",
+            "additionalProperties": false,
+            "properties": {
+                "github": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "wiki": {
+                                "$ref": "#/definitions/wiki"
+                            },
+                            "starred": {
+                                "$ref": "#/definitions/starred"
+                            },
+                            "issues": {
+                                "$ref": "#/definitions/issues"
+                            },
+                            "filter": {
+                                "$ref": "#/definitions/filter"
+                            }
+                        }
+                    }
+                },
+                "gitlab": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "wiki": {
+                                "$ref": "#/definitions/wiki"
+                            },
+                            "starred": {
+                                "$ref": "#/definitions/starred"
+                            },
+                            "issues": {
+                                "$ref": "#/definitions/issues"
+                            },
+                            "filter": {
+                                "$ref": "#/definitions/filter"
+                            }
+                        }
+                    }
+                },
+                "gitea": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "wiki": {
+                                "$ref": "#/definitions/wiki"
+                            },
+                            "starred": {
+                                "$ref": "#/definitions/starred"
+                            },
+                            "issues": {
+                                "$ref": "#/definitions/issues"
+                            },
+                            "filter": {
+                                "$ref": "#/definitions/filter"
+                            }
+                        }
+                    }
+                },
+                "gogs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "wiki": {
+                                "$ref": "#/definitions/wiki"
+                            },
+                            "starred": {
+                                "$ref": "#/definitions/starred"
+                            },
+                            "issues": {
+                                "$ref": "#/definitions/issues"
+                            },
+                            "filter": {
+                                "type": "object",
+                                "properties": {
+                                    "lastactivity": {
+                                        "$ref": "#/definitions/filter/properties/lastactivity"
+                                    },
+                                    "stars": {
+                                        "$ref": "#/definitions/filter/properties/stars"
+                                    },
+                                    "excludeforks": {
+                                        "$ref": "#/definitions/filter/properties/excludeforks"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "onedev": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "issues": {
+                                "$ref": "#/definitions/issues"
+                            },
+                            "filter": {
+                                "type": "object",
+                                "properties": {
+                                    "lastactivity": {
+                                        "$ref": "#/definitions/filter/properties/lastactivity"
+                                    },
+                                    "excludeforks": {
+                                        "$ref": "#/definitions/filter/properties/excludeforks"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "sourcehut": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "wiki": {
+                                "$ref": "#/definitions/wiki"
+                            },
+                            "filter": {
+                                "type": "object",
+                                "properties": {
+                                    "lastactivity": {
+                                        "$ref": "#/definitions/filter/properties/lastactivity"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "bitbucket": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "exclude": {
+                                "$ref": "#/definitions/exclude"
+                            },
+                            "include": {
+                                "$ref": "#/definitions/include"
+                            },
+                            "excludeorgs": {
+                                "$ref": "#/definitions/excludeorgs"
+                            },
+                            "includeorgs": {
+                                "$ref": "#/definitions/includeorgs"
+                            },
+                            "filter": {
+                                "type": "object",
+                                "properties": {
+                                    "lastactivity": {
+                                        "$ref": "#/definitions/filter/properties/lastactivity"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "any": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "username": {
+                                "$ref": "#/definitions/username"
+                            },
+                            "password": {
+                                "$ref": "#/definitions/password"
+                            },
+                            "ssh": {
+                                "$ref": "#/definitions/ssh"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            }
+                        }
+                    },
+                    "required": ["url"]
+                }
+            }
+        },
+
+        "destination": {
+            "type": "object",
+            "description": "Configuration for all git hoster destination endpoints",
+            "additionalProperties": false,
+            "properties": {
+                "local": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "path to store your backup"
+                            },
+                            "structured": {
+                                "type": "boolean",
+                                "description": "if set to `true`, it checks out the repos in a more structured way, like `hoster/user|organization/repository`"
+                            },
+                            "zip": {
+                                "type": "boolean",
+                                "description": "zips the repository"
+                            },
+                            "keep": {
+                                "type": "integer",
+                                "description": "keeps x latest backups"
+                            },
+                            "bare": {
+                                "type": "boolean",
+                                "description": "clone the repository as a bare repository"
+                            },
+                            "lfs": {
+                                "type": "boolean",
+                                "description": "uses lfs to clone repositories"
+                            }
+                        },
+                        "required": ["path"],
+                        "additionalProperties": false
+                    }
+                },
+                "s3": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "properties": {
+                                "endpoint": {
+                                    "type": "string",
+                                    "description": "The endpoint of the S3 server"
+                                },
+                                "structured": {
+                                    "type": "boolean",
+                                    "description": "if set to `true`, it checks out the repos in a more structured way, like `hoster/user|organization/repository`"
+                                },
+                                "bucket": {
+                                    "type": "string",
+                                    "description": "The bucket to store the backups in"
+                                },
+                                "accesskey": {
+                                    "type": "string",
+                                    "description": "The access key to authenticate against the S3 server"
+                                },
+                                "secretkey": {
+                                    "type": "string",
+                                    "description": "The secret key to authenticate against the S3 server"
+                                },
+                                "usessl": {
+                                    "type": "boolean",
+                                    "description": "Use SSL to connect to the S3 server"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "github": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "organization": {
+                                "$ref": "#/definitions/organization"
+                            },
+                            "force": {
+                                "$ref": "#/definitions/force"
+                            },
+                            "visibility": {
+                                "type": "object",
+                                "properties": {
+                                    "repositories": {
+                                        "$ref": "#/definitions/visibility/properties/repositories"
+                                    }
+                                }
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "gitlab": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "force": {
+                                "$ref": "#/definitions/force"
+                            },
+                            "mirror": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "$ref": "#/definitions/mirror/properties/enabled"
+                                    }
+                                }
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "gitea": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "createorg": {
+                                "type": "boolean",
+                                "description": "if activated, it will create the value in user as organization if it doesn't exist on the system"
+                            },
+                            "lfs": {
+                                "type": "boolean",
+                                "description": "uses lfs to clone repositories"
+                            },
+                            "force": {
+                                "$ref": "#/definitions/force"
+                            },
+                            "mirror": {
+                                "$ref": "#/definitions/mirror"
+                            },
+                            "visibility": {
+                                "$ref": "#/definitions/visibility"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "gogs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/user"
+                            },
+                            "force": {
+                                "$ref": "#/definitions/force"
+                            },
+                            "mirror": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "$ref": "#/definitions/mirror/properties/enabled"
+                                    }
+                                }
+                            },
+                            "visibility": {
+                                "type": "object",
+                                "properties": {
+                                    "repositories": {
+                                        "$ref": "#/definitions/visibility/properties/repositories"
+                                    }
+                                }
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "onedev": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "organization": {
+                                "$ref": "#/definitions/organization"
+                            },
+                            "force": {
+                                "$ref": "#/definitions/force"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "sourcehut": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "token": {
+                                "$ref": "#/definitions/token"
+                            },
+                            "token_file": {
+                                "$ref": "#/definitions/token_file"
+                            },
+                            "url": {
+                                "$ref": "#/definitions/url"
+                            },
+                            "sshkey": {
+                                "$ref": "#/definitions/sshkey"
+                            },
+                            "force": {
+                                "$ref": "#/definitions/force"
+                            },
+                            "visibility": {
+                                "type": "object",
+                                "properties": {
+                                    "repositories": {
+                                        "$ref": "#/definitions/visibility/properties/repositories"
+                                    }
+                                }
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            }
+        }
+    },
+
+    "definitions": {
+        "token": {
+            "type": "string",
+            "description": "The token to authenticate against the destination"
+        },
+        "token_file": {
+            "type": "string",
+            "description": "Alternatively, specify the token in a file, relative to current working directory when executed"
+        },
+        "url": {
+            "type": "string",
+            "description": "The url to the source repository"
+        },
+        "user": {
+            "type": "string",
+            "description": "The user you want to clone the repositories from. If you want to get everything from your user, leave out the user parameter and just use the token."
+        },
+        "organization": {
+            "type": "string",
+            "description": "The organization to clone the repositories to"
+        },
+        "username": {
+            "type": "string",
+            "description": "The username to authenticate against the destination"
+        },
+        "password": {
+            "type": "string",
+            "description": "The password to authenticate against the destination"
+        },
+        "ssh": {
+            "type": "boolean",
+            "description": "Use ssh instead of https to clone the repositories"
+        },
+        "sshkey": {
+            "type": "string",
+            "description": "The path to the ssh key to use for cloning the repositories"
+        },
+        "force": {
+            "type": "boolean",
+            "description": "Force push to the destination"
+        },
+        "exclude": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "A list of repositories to exclude from the backup"
+        },
+        "include": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "A list of repositories to include in the backup"
+        },
+        "excludeorgs": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "A list of organizations to exclude from the backup"
+        },
+        "includeorgs": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "description": "A list of organizations to include in the backup"
+        },
+        "wiki": {
+            "type": "boolean",
+            "description": "Clone the wiki repositories as well"
+        },
+        "starred": {
+            "type": "boolean",
+            "description": "Clone the starred repositories as well"
+        },
+        "issues": {
+            "type": "boolean",
+            "description": "Clone the issues as well"
+        },
+        "filter": {
+            "$id": "#/definitions/filter",
+            "type": "object",
+            "properties": {
+                "lastactivity": {
+                    "$id": "#/definitions/filter/properties/lastactivity",
+                    "type": "string",
+                    "description": "Only clone repositories that have been active in the last x days. The value is a string that can be parsed by the time.ParseDuration function from the go standard library."
+                },
+                "stars": {
+                    "$id": "#/definitions/filter/properties/stars",
+                    "type": "integer",
+                    "description": "Only clone repositories that have more than x stars"
+                },
+                "excludearchived": {
+                    "$id": "#/definitions/filter/properties/excludearchived",
+                    "type": "boolean",
+                    "description": "Exclude archived repositories"
+                },
+                "excludeforks": {
+                    "$id": "#/definitions/filter/properties/excludeforks",
+                    "type": "boolean",
+                    "description": "Exclude forked repositories"
+                },
+                "languages": {
+                    "$id": "#/definitions/filter/properties/languages",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Only clone repositories that are written in one of the specified languages"
+                }
+            }
+        },
+        "visibility": {
+            "$id": "#/definitions/visibility",
+            "type": "object",
+            "properties": {
+                "repositories": {
+                    "$id": "#/definitions/visibility/properties/repositories",
+                    "type": "string",
+                    "enum": ["public", "private"],
+                    "description": "The visibility of the repositories to clone"
+                },
+                "organizations": {
+                    "$id": "#/definitions/visibility/properties/organizations",
+                    "type": "string",
+                    "enum": ["public", "private", "limited"],
+                    "description": "The visibility of the organizations to clone"
+                }
+            }
+        },
+        "mirror": {
+            "$id": "#/definitions/mirror",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "$id": "#/definitions/mirror/properties/enabled",
+                    "type": "boolean",
+                    "description": "Enable mirroring of the repositories"
+                },
+                "mirrorinterval": {
+                    "$id": "#/definitions/mirror/properties/mirrorinterval",
+                    "type": "string",
+                    "description": "The interval to mirror the repositories. The value is a string that can be parsed by the time.ParseDuration function from the go standard library."
+                }
+            }
+        }
+    }
+}

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -712,45 +712,56 @@
     },
     "definitions": {
         "source": {
+            "$id": "#/definitions/source",
             "type": "object",
             "properties": {
                 "token": {
+                    "$id": "#/definitions/source/properties/token",
                     "type": "string",
                     "description": "The token to authenticate against the source"
                 },
                 "token_file": {
+                    "$id": "#/definitions/source/properties/token_file",
                     "type": "string",
                     "description": "Alternatively, specify the token in a file, relative to current working directory when executed"
                 },
                 "url": {
+                    "$id": "#/definitions/source/properties/url",
                     "type": "string",
                     "description": "The url to the source repository"
                 },
                 "user": {
+                    "$id": "#/definitions/source/properties/user",
                     "type": "string",
                     "description": "The user you want to clone the repositories from. If you want to get everything from your user, leave out the user parameter and just use the token."
                 },
                 "organization": {
+                    "$id": "#/definitions/source/properties/organization",
                     "type": "string",
                     "description": "The organization to clone the repositories from"
                 },
                 "username": {
+                    "$id": "#/definitions/source/properties/username",
                     "type": "string",
                     "description": "The username to authenticate against the source"
                 },
                 "password": {
+                    "$id": "#/definitions/source/properties/password",
                     "type": "string",
                     "description": "The password to authenticate against the source"
                 },
                 "ssh": {
+                    "$id": "#/definitions/source/properties/ssh",
                     "type": "boolean",
                     "description": "Use ssh instead of https to clone the repositories"
                 },
                 "sshkey": {
+                    "$id": "#/definitions/source/properties/sshkey",
                     "type": "string",
                     "description": "The path to the ssh key to use for cloning the repositories"
                 },
                 "exclude": {
+                    "$id": "#/definitions/source/properties/exclude",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -759,6 +770,7 @@
                     "description": "A list of repositories to exclude from the backup"
                 },
                 "include": {
+                    "$id": "#/definitions/source/properties/include",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -767,6 +779,7 @@
                     "description": "A list of repositories to include in the backup"
                 },
                 "excludeorgs": {
+                    "$id": "#/definitions/source/properties/excludeorgs",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -775,6 +788,7 @@
                     "description": "A list of organizations to exclude from the backup"
                 },
                 "includeorgs": {
+                    "$id": "#/definitions/source/properties/includeorgs",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -783,55 +797,68 @@
                     "description": "A list of organizations to include in the backup"
                 },
                 "wiki": {
+                    "$id": "#/definitions/source/properties/wiki",
                     "type": "boolean",
                     "description": "Include the wiki in the backup"
                 },
                 "starred": {
+                    "$id": "#/definitions/source/properties/starred",
                     "type": "boolean",
                     "description": "Include the starred repositories in the backup"
                 },
                 "issues": {
+                    "$id": "#/definitions/source/properties/issues",
                     "type": "boolean",
                     "description": "Include the issues in the backup, only available for `local` destination"
                 }
             }
         },
         "destination": {
+            "$id": "#/definitions/destination",
             "type": "object",
             "properties": {
                 "token": {
+                    "$id": "#/definitions/destination/properties/token",
                     "type": "string",
                     "description": "The token to authenticate against the destination"
                 },
                 "token_file": {
+                    "$id": "#/definitions/destination/properties/token_file",
                     "type": "string",
                     "description": "Alternatively, specify the token in a file, relative to current working directory when executed"
                 },
                 "url": {
+                    "$id": "#/definitions/destination/properties/url",
                     "type": "string",
                     "description": "The url to the destination repository"
                 },
                 "user": {
+                    "$id": "#/definitions/destination/properties/user",
                     "type": "string",
                     "description": "The user/org you want to backup the repositories to"
                 },
                 "organization": {
+                    "$id": "#/definitions/destination/properties/organization",
                     "type": "string",
                     "description": "The organization to backup the repositories to"
                 },
                 "sshkey": {
+                    "$id": "#/definitions/destination/properties/sshkey",
                     "type": "string",
                     "description": "The path to the ssh key to use for pushing the repositories"
                 },
                 "createorg": {
+                    "$id": "#/definitions/destination/properties/createorg",
                     "type": "boolean",
                     "description": "Create the organization if it does not exist"
                 },
                 "lfs": {
+                    "$id": "#/definitions/destination/properties/lfs",
                     "type": "boolean",
                     "description": "Use lfs to push the repositories"
                 },
                 "force": {
+                    "$id": "#/definitions/destination/properties/force",
                     "type": "boolean",
                     "description": "Force push the repositories"
                 }

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -4,9 +4,7 @@
     "type": "object",
     "title": "Gickup configuration spec",
     "description": "The Gickup configuration spec",
-
     "properties": {
-
         "source": {
             "type": "object",
             "description": "Configuration for all git hoster source endpoints",
@@ -18,46 +16,46 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "wiki": {
-                                "$ref": "#/definitions/wiki"
+                                "$ref": "#/definitions/source/properties/wiki"
                             },
                             "starred": {
-                                "$ref": "#/definitions/starred"
+                                "$ref": "#/definitions/source/properties/starred"
                             },
                             "issues": {
-                                "$ref": "#/definitions/issues"
+                                "$ref": "#/definitions/source/properties/issues"
                             },
                             "filter": {
                                 "$ref": "#/definitions/filter"
@@ -71,49 +69,49 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "wiki": {
-                                "$ref": "#/definitions/wiki"
+                                "$ref": "#/definitions/source/properties/wiki"
                             },
                             "starred": {
-                                "$ref": "#/definitions/starred"
+                                "$ref": "#/definitions/source/properties/starred"
                             },
                             "issues": {
-                                "$ref": "#/definitions/issues"
+                                "$ref": "#/definitions/source/properties/issues"
                             },
                             "filter": {
                                 "$ref": "#/definitions/filter"
@@ -127,49 +125,49 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "wiki": {
-                                "$ref": "#/definitions/wiki"
+                                "$ref": "#/definitions/source/properties/wiki"
                             },
                             "starred": {
-                                "$ref": "#/definitions/starred"
+                                "$ref": "#/definitions/source/properties/starred"
                             },
                             "issues": {
-                                "$ref": "#/definitions/issues"
+                                "$ref": "#/definitions/source/properties/issues"
                             },
                             "filter": {
                                 "$ref": "#/definitions/filter"
@@ -183,49 +181,49 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "wiki": {
-                                "$ref": "#/definitions/wiki"
+                                "$ref": "#/definitions/source/properties/wiki"
                             },
                             "starred": {
-                                "$ref": "#/definitions/starred"
+                                "$ref": "#/definitions/source/properties/starred"
                             },
                             "issues": {
-                                "$ref": "#/definitions/issues"
+                                "$ref": "#/definitions/source/properties/issues"
                             },
                             "filter": {
                                 "type": "object",
@@ -250,43 +248,43 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "issues": {
-                                "$ref": "#/definitions/issues"
+                                "$ref": "#/definitions/source/properties/issues"
                             },
                             "filter": {
                                 "type": "object",
@@ -308,43 +306,43 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "wiki": {
-                                "$ref": "#/definitions/wiki"
+                                "$ref": "#/definitions/source/properties/wiki"
                             },
                             "filter": {
                                 "type": "object",
@@ -363,40 +361,40 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/source/properties/user"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             },
                             "exclude": {
-                                "$ref": "#/definitions/exclude"
+                                "$ref": "#/definitions/source/properties/exclude"
                             },
                             "include": {
-                                "$ref": "#/definitions/include"
+                                "$ref": "#/definitions/source/properties/include"
                             },
                             "excludeorgs": {
-                                "$ref": "#/definitions/excludeorgs"
+                                "$ref": "#/definitions/source/properties/excludeorgs"
                             },
                             "includeorgs": {
-                                "$ref": "#/definitions/includeorgs"
+                                "$ref": "#/definitions/source/properties/includeorgs"
                             },
                             "filter": {
                                 "type": "object",
@@ -415,33 +413,34 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/source/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/source/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/source/properties/url"
                             },
                             "username": {
-                                "$ref": "#/definitions/username"
+                                "$ref": "#/definitions/source/properties/username"
                             },
                             "password": {
-                                "$ref": "#/definitions/password"
+                                "$ref": "#/definitions/source/properties/password"
                             },
                             "ssh": {
-                                "$ref": "#/definitions/ssh"
+                                "$ref": "#/definitions/source/properties/ssh"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/source/properties/sshkey"
                             }
                         }
                     },
-                    "required": ["url"]
+                    "required": [
+                        "url"
+                    ]
                 }
             }
         },
-
         "destination": {
             "type": "object",
             "description": "Configuration for all git hoster destination endpoints",
@@ -477,7 +476,9 @@
                                 "description": "uses lfs to clone repositories"
                             }
                         },
-                        "required": ["path"],
+                        "required": [
+                            "path"
+                        ],
                         "additionalProperties": false
                     }
                 },
@@ -522,16 +523,16 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/destination/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/destination/properties/token_file"
                             },
                             "organization": {
-                                "$ref": "#/definitions/organization"
+                                "$ref": "#/definitions/destination/properties/organization"
                             },
                             "force": {
-                                "$ref": "#/definitions/force"
+                                "$ref": "#/definitions/destination/properties/force"
                             },
                             "visibility": {
                                 "type": "object",
@@ -551,16 +552,16 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/destination/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/destination/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/destination/properties/url"
                             },
                             "force": {
-                                "$ref": "#/definitions/force"
+                                "$ref": "#/definitions/destination/properties/force"
                             },
                             "mirror": {
                                 "type": "object",
@@ -580,24 +581,22 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/destination/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/destination/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/destination/properties/url"
                             },
                             "createorg": {
-                                "type": "boolean",
-                                "description": "if activated, it will create the value in user as organization if it doesn't exist on the system"
+                                "$ref": "#/definitions/destination/properties/createorg"
                             },
                             "lfs": {
-                                "type": "boolean",
-                                "description": "uses lfs to clone repositories"
+                                "$ref": "#/definitions/destination/properties/lfs"
                             },
                             "force": {
-                                "$ref": "#/definitions/force"
+                                "$ref": "#/definitions/destination/properties/force"
                             },
                             "mirror": {
                                 "$ref": "#/definitions/mirror"
@@ -615,19 +614,22 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/destination/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/destination/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/destination/properties/url"
                             },
                             "user": {
-                                "$ref": "#/definitions/user"
+                                "$ref": "#/definitions/destination/properties/user"
+                            },
+                            "createorg": {
+                                "$ref": "#/definitions/destination/properties/createorg"
                             },
                             "force": {
-                                "$ref": "#/definitions/force"
+                                "$ref": "#/definitions/destination/properties/force"
                             },
                             "mirror": {
                                 "type": "object",
@@ -655,19 +657,19 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/destination/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/destination/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/destination/properties/url"
                             },
                             "organization": {
-                                "$ref": "#/definitions/organization"
+                                "$ref": "#/definitions/destination/properties/organization"
                             },
                             "force": {
-                                "$ref": "#/definitions/force"
+                                "$ref": "#/definitions/destination/properties/force"
                             }
                         },
                         "additionalProperties": false
@@ -679,19 +681,19 @@
                         "type": "object",
                         "properties": {
                             "token": {
-                                "$ref": "#/definitions/token"
+                                "$ref": "#/definitions/destination/properties/token"
                             },
                             "token_file": {
-                                "$ref": "#/definitions/token_file"
+                                "$ref": "#/definitions/destination/properties/token_file"
                             },
                             "url": {
-                                "$ref": "#/definitions/url"
+                                "$ref": "#/definitions/destination/properties/url"
                             },
                             "sshkey": {
-                                "$ref": "#/definitions/sshkey"
+                                "$ref": "#/definitions/destination/properties/sshkey"
                             },
                             "force": {
-                                "$ref": "#/definitions/force"
+                                "$ref": "#/definitions/destination/properties/force"
                             },
                             "visibility": {
                                 "type": "object",
@@ -708,91 +710,132 @@
             }
         }
     },
-
     "definitions": {
-        "token": {
-            "type": "string",
-            "description": "The token to authenticate against the destination"
+        "source": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "The token to authenticate against the source"
+                },
+                "token_file": {
+                    "type": "string",
+                    "description": "Alternatively, specify the token in a file, relative to current working directory when executed"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The url to the source repository"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "The user you want to clone the repositories from. If you want to get everything from your user, leave out the user parameter and just use the token."
+                },
+                "organization": {
+                    "type": "string",
+                    "description": "The organization to clone the repositories from"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "The username to authenticate against the source"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "The password to authenticate against the source"
+                },
+                "ssh": {
+                    "type": "boolean",
+                    "description": "Use ssh instead of https to clone the repositories"
+                },
+                "sshkey": {
+                    "type": "string",
+                    "description": "The path to the ssh key to use for cloning the repositories"
+                },
+                "exclude": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "description": "A list of repositories to exclude from the backup"
+                },
+                "include": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "description": "A list of repositories to include in the backup"
+                },
+                "excludeorgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "description": "A list of organizations to exclude from the backup"
+                },
+                "includeorgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "description": "A list of organizations to include in the backup"
+                },
+                "wiki": {
+                    "type": "boolean",
+                    "description": "Include the wiki in the backup"
+                },
+                "starred": {
+                    "type": "boolean",
+                    "description": "Include the starred repositories in the backup"
+                },
+                "issues": {
+                    "type": "boolean",
+                    "description": "Include the issues in the backup, only available for `local` destination"
+                }
+            }
         },
-        "token_file": {
-            "type": "string",
-            "description": "Alternatively, specify the token in a file, relative to current working directory when executed"
-        },
-        "url": {
-            "type": "string",
-            "description": "The url to the source repository"
-        },
-        "user": {
-            "type": "string",
-            "description": "The user you want to clone the repositories from. If you want to get everything from your user, leave out the user parameter and just use the token."
-        },
-        "organization": {
-            "type": "string",
-            "description": "The organization to clone the repositories to"
-        },
-        "username": {
-            "type": "string",
-            "description": "The username to authenticate against the destination"
-        },
-        "password": {
-            "type": "string",
-            "description": "The password to authenticate against the destination"
-        },
-        "ssh": {
-            "type": "boolean",
-            "description": "Use ssh instead of https to clone the repositories"
-        },
-        "sshkey": {
-            "type": "string",
-            "description": "The path to the ssh key to use for cloning the repositories"
-        },
-        "force": {
-            "type": "boolean",
-            "description": "Force push to the destination"
-        },
-        "exclude": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true,
-            "description": "A list of repositories to exclude from the backup"
-        },
-        "include": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true,
-            "description": "A list of repositories to include in the backup"
-        },
-        "excludeorgs": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true,
-            "description": "A list of organizations to exclude from the backup"
-        },
-        "includeorgs": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true,
-            "description": "A list of organizations to include in the backup"
-        },
-        "wiki": {
-            "type": "boolean",
-            "description": "Clone the wiki repositories as well"
-        },
-        "starred": {
-            "type": "boolean",
-            "description": "Clone the starred repositories as well"
-        },
-        "issues": {
-            "type": "boolean",
-            "description": "Clone the issues as well"
+        "destination": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "The token to authenticate against the destination"
+                },
+                "token_file": {
+                    "type": "string",
+                    "description": "Alternatively, specify the token in a file, relative to current working directory when executed"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The url to the destination repository"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "The user/org you want to backup the repositories to"
+                },
+                "organization": {
+                    "type": "string",
+                    "description": "The organization to backup the repositories to"
+                },
+                "sshkey": {
+                    "type": "string",
+                    "description": "The path to the ssh key to use for pushing the repositories"
+                },
+                "createorg": {
+                    "type": "boolean",
+                    "description": "Create the organization if it does not exist"
+                },
+                "lfs": {
+                    "type": "boolean",
+                    "description": "Use lfs to push the repositories"
+                },
+                "force": {
+                    "type": "boolean",
+                    "description": "Force push the repositories"
+                }
+            }
         },
         "filter": {
             "$id": "#/definitions/filter",
@@ -835,13 +878,20 @@
                 "repositories": {
                     "$id": "#/definitions/visibility/properties/repositories",
                     "type": "string",
-                    "enum": ["public", "private"],
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
                     "description": "The visibility of the repositories to clone"
                 },
                 "organizations": {
                     "$id": "#/definitions/visibility/properties/organizations",
                     "type": "string",
-                    "enum": ["public", "private", "limited"],
+                    "enum": [
+                        "public",
+                        "private",
+                        "limited"
+                    ],
                     "description": "The visibility of the organizations to clone"
                 }
             }

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -5,6 +5,16 @@
     "title": "Gickup configuration spec",
     "description": "The Gickup configuration spec",
     "properties": {
+        "cron": {
+            "type": "string",
+            "description": "The cron expression to run the backup, You can create and test the expression on https://crontab.guru/"
+        },
+        "log": {
+            "$ref": "#/definitions/log"
+        },
+        "metrics": {
+            "$ref": "#/definitions/metrics"
+        },
         "source": {
             "type": "object",
             "description": "Configuration for all git hoster source endpoints",
@@ -725,16 +735,6 @@
                     }
                 }
             }
-        },
-        "cron": {
-            "type": "string",
-            "description": "The cron expression to run the backup, You can create and test the expression on https://crontab.guru/"
-        },
-        "log": {
-            "$ref": "#/definitions/log"
-        },
-        "metrics": {
-            "$ref": "#/definitions/metrics"
         }
     },
     "definitions": {
@@ -972,7 +972,9 @@
             "additionalProperties": false
         },
         "log": {
+            "$id": "#/definitions/log",
             "type": "object",
+            "description": "Configure logging related settings (optional)",
             "properties": {
                 "timeformat": {
                     "type": "string",
@@ -980,6 +982,7 @@
                 },
                 "file-logging": {
                     "type": "object",
+                    "description": "Configure file logging (optional)",
                     "properties": {
                         "dir": {
                             "type": "string",
@@ -1000,10 +1003,13 @@
             "additionalProperties": false
         },
         "metrics": {
+            "$id": "#/definitions/metrics",
             "type": "object",
+            "description": "Configure metrics related settings (optional)",
             "properties": {
                 "prometheus": {
                     "type": "object",
+                    "description": "Configure prometheus metrics (optional)",
                     "properties": {
                         "endpoint": {
                             "type": "string",
@@ -1018,6 +1024,7 @@
                 },
                 "heartbeat": {
                     "type": "object",
+                    "description": "Configure heartbeat for services like https://healthchecks.io/ or https://deadmanssnitch.com/ (optional)",
                     "properties": {
                         "urls": {
                             "type": "array",
@@ -1030,15 +1037,17 @@
                 },
                 "push": {
                     "type": "object",
+                    "description": "Configure pushgateways to get notifications on your phone or browser (optional)",
                     "properties": {
                         "ntfy": {
                             "type": "array",
+                            "description": "Send notifications to ntfy.sh (optional)",
                             "items": {
                                 "type": "object",
                                 "properties": {
                                     "url": {
                                         "type": "string",
-                                        "description": "The url to push the metrics to"
+                                        "description": "The url to your nty server"
                                     },
                                     "token": {
                                         "type": "string",
@@ -1057,12 +1066,13 @@
                         },
                         "gotify": {
                             "type": "array",
+                            "description": "Send notifications to gotify.net (optional)",
                             "items": {
                                 "type": "object",
                                 "properties": {
                                     "url": {
                                         "type": "string",
-                                        "description": "The url to push the metrics to"
+                                        "description": "The url to your gotify server"
                                     },
                                     "token": {
                                         "type": "string",

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -67,6 +67,9 @@
                             "issues": {
                                 "$ref": "#/definitions/source/properties/issues"
                             },
+                            "gists": {
+                                "$ref": "#/definitions/source/properties/gists"
+                            },
                             "filter": {
                                 "$ref": "#/definitions/filter"
                             }
@@ -442,6 +445,9 @@
                             "url": {
                                 "$ref": "#/definitions/source/properties/url"
                             },
+                            "user": {
+                                "$ref": "#/definitions/source/properties/user"
+                            },
                             "username": {
                                 "$ref": "#/definitions/source/properties/username"
                             },
@@ -613,6 +619,9 @@
                             "url": {
                                 "$ref": "#/definitions/destination/properties/url"
                             },
+                            "user": {
+                                "$ref": "#/definitions/destination/properties/user"
+                            },
                             "createorg": {
                                 "$ref": "#/definitions/destination/properties/createorg"
                             },
@@ -714,6 +723,9 @@
                             },
                             "url": {
                                 "$ref": "#/definitions/destination/properties/url"
+                            },
+                            "user": {
+                                "$ref": "#/definitions/destination/properties/user"
                             },
                             "sshkey": {
                                 "$ref": "#/definitions/destination/properties/sshkey"
@@ -837,6 +849,11 @@
                     "$id": "#/definitions/source/properties/issues",
                     "type": "boolean",
                     "description": "Include the issues in the backup, only available for `local` destination"
+                },
+                "gists": {
+                    "$id": "#/definitions/source/properties/gists",
+                    "type": "boolean",
+                    "description": "Include the gists in the backup"
                 }
             },
             "additionalProperties": false

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -60,7 +60,8 @@
                             "filter": {
                                 "$ref": "#/definitions/filter"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "gitlab": {
@@ -116,7 +117,8 @@
                             "filter": {
                                 "$ref": "#/definitions/filter"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "gitea": {
@@ -172,7 +174,8 @@
                             "filter": {
                                 "$ref": "#/definitions/filter"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "gogs": {
@@ -237,9 +240,11 @@
                                     "excludeforks": {
                                         "$ref": "#/definitions/filter/properties/excludeforks"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "onedev": {
@@ -295,9 +300,11 @@
                                     "excludeforks": {
                                         "$ref": "#/definitions/filter/properties/excludeforks"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "sourcehut": {
@@ -350,9 +357,11 @@
                                     "lastactivity": {
                                         "$ref": "#/definitions/filter/properties/lastactivity"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "bitbucket": {
@@ -402,9 +411,11 @@
                                     "lastactivity": {
                                         "$ref": "#/definitions/filter/properties/lastactivity"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "any": {
@@ -433,7 +444,8 @@
                             "sshkey": {
                                 "$ref": "#/definitions/source/properties/sshkey"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     },
                     "required": [
                         "url"
@@ -540,7 +552,8 @@
                                     "repositories": {
                                         "$ref": "#/definitions/visibility/properties/repositories"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "additionalProperties": false
@@ -569,7 +582,8 @@
                                     "enabled": {
                                         "$ref": "#/definitions/mirror/properties/enabled"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "additionalProperties": false
@@ -637,7 +651,8 @@
                                     "enabled": {
                                         "$ref": "#/definitions/mirror/properties/enabled"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             },
                             "visibility": {
                                 "type": "object",
@@ -645,7 +660,8 @@
                                     "repositories": {
                                         "$ref": "#/definitions/visibility/properties/repositories"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "additionalProperties": false
@@ -701,13 +717,24 @@
                                     "repositories": {
                                         "$ref": "#/definitions/visibility/properties/repositories"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "additionalProperties": false
                     }
                 }
             }
+        },
+        "cron": {
+            "type": "string",
+            "description": "The cron expression to run the backup, You can create and test the expression on https://crontab.guru/"
+        },
+        "log": {
+            "$ref": "#/definitions/log"
+        },
+        "metrics": {
+            "$ref": "#/definitions/metrics"
         }
     },
     "definitions": {
@@ -811,7 +838,8 @@
                     "type": "boolean",
                     "description": "Include the issues in the backup, only available for `local` destination"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "destination": {
             "$id": "#/definitions/destination",
@@ -862,7 +890,8 @@
                     "type": "boolean",
                     "description": "Force push the repositories"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "filter": {
             "$id": "#/definitions/filter",
@@ -896,7 +925,8 @@
                     },
                     "description": "Only clone repositories that are written in one of the specified languages"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "visibility": {
             "$id": "#/definitions/visibility",
@@ -921,7 +951,8 @@
                     ],
                     "description": "The visibility of the organizations to clone"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "mirror": {
             "$id": "#/definitions/mirror",
@@ -937,7 +968,114 @@
                     "type": "string",
                     "description": "The interval to mirror the repositories. The value is a string that can be parsed by the time.ParseDuration function from the go standard library."
                 }
-            }
+            },
+            "additionalProperties": false
+        },
+        "log": {
+            "type": "object",
+            "properties": {
+                "timeformat": {
+                    "type": "string",
+                    "description": "The time format to use in the logs, The basics for time formats can be found at https://yourbasic.org/golang/format-parse-string-time-date-example."
+                },
+                "file-logging": {
+                    "type": "object",
+                    "properties": {
+                        "dir": {
+                            "type": "string",
+                            "description": "The directory to store the logs in"
+                        },
+                        "file": {
+                            "type": "string",
+                            "description": "The file to store the logs in"
+                        },
+                        "maxage": {
+                            "type": "integer",
+                            "description": "The maximum age of the log file in days"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "prometheus": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string",
+                            "description": "The endpoint to expose the metrics on"
+                        },
+                        "listen_addr": {
+                            "type": "string",
+                            "description": "The address to listen on"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "heartbeat": {
+                    "type": "object",
+                    "properties": {
+                        "urls": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "A list of urls to check for heartbeat"
+                        }
+                    }
+                },
+                "push": {
+                    "type": "object",
+                    "properties": {
+                        "ntfy": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "description": "The url to push the metrics to"
+                                    },
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The token to authenticate against the nty server"
+                                    },
+                                    "user": {
+                                        "type": "string",
+                                        "description": "The user to authenticate against the nty server"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "description": "The password to authenticate against the nty server"
+                                    }
+                                }
+                            }
+                        },
+                        "gotify": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "description": "The url to push the metrics to"
+                                    },
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The token to authenticate against the gotify server"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
         }
     }
 }


### PR DESCRIPTION
The json schema is based on the https://cooperspencer.github.io/gickup-documentation/category/configuration site.

**Example screenshot**:

<img width="468" alt="image" src="https://github.com/user-attachments/assets/bbd13575-05d6-4b1a-a945-89834d00c9af" />

> [!NOTE]
> Visual Studio Code does not support YAML using JSON Schema out of the box. You have to use the [YAML extension created by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).