### PR TITLE
Bitbucket: don't assume default personal workspace exists

### DIFF
--- a/bitbucket/bitbucket.go
+++ b/bitbucket/bitbucket.go
@@ -64,10 +64,7 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 
 		repo_res, err := client.Repositories.ListForAccount(&bitbucket.RepositoriesOptions{Owner: repo.User})
 		var repositories []bitbucket.Repository
-		if err != nil {
-			sub.Error().
-				Msg(err.Error())
-		} else {
+		if err == nil {
 			repositories = repo_res.Items
 		}
 

--- a/bitbucket/bitbucket.go
+++ b/bitbucket/bitbucket.go
@@ -62,11 +62,13 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 		sub.Info().
 			Msgf("grabbing repositories from %s", repo.User)
 
-		repositories, err := client.Repositories.ListForAccount(&bitbucket.RepositoriesOptions{Owner: repo.User})
+		repo_res, err := client.Repositories.ListForAccount(&bitbucket.RepositoriesOptions{Owner: repo.User})
+		var repositories []bitbucket.Repository
 		if err != nil {
 			sub.Error().
 				Msg(err.Error())
-			continue
+		} else {
+			repositories = repo_res.Items
 		}
 
 		if repo.Token != "" {
@@ -92,7 +94,7 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 							sub.Error().
 								Msg(err.Error())
 						} else {
-							repositories.Items = append(repositories.Items, workspacerepos.Items...)
+							repositories = append(repositories, workspacerepos.Items...)
 						}
 
 					}
@@ -100,7 +102,7 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 			}
 		}
 
-		for _, r := range repositories.Items {
+		for _, r := range repositories {
 			sub.Debug().Msg(r.Links["clone"].([]interface{})[0].(map[string]interface{})["href"].(string))
 			user := repo.User
 			if r.Owner != nil {


### PR DESCRIPTION
Right now, the Bitbucket source assumes that a default, personal workspace exists with the same name as the username.
[This is no longer the case nowadays](https://community.atlassian.com/forums/Bitbucket-questions/Re-Why-doesn-t-my-bitbucket-have-a-default-personal-work/qaq-p/2277433/comment-id/90629#M90629).

With these changes, instead of crashing if the personal workspace does not exist, the program still tries to back up repos from other workspaces.
