### PR TITLE
fix: Fetch LFS files explicitly in bare repositories

### DIFF
--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -51,6 +51,16 @@ func (g GitCmd) Fetch(path string) error {
 	return cmd.Run()
 }
 
+func (g GitCmd) LFSFetch(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	args := []string{"-C", path, "lfs", "fetch", "--all"}
+	cmd := exec.Command(g.CMD, args...)
+	return cmd.Run()
+}
+
 func (g GitCmd) MirrorPull(path string) error {
 	_, err := os.Stat(path)
 	if err != nil {

--- a/local/local.go
+++ b/local/local.go
@@ -333,6 +333,16 @@ func updateRepository(reponame string, auth transport.AuthMethod, dry bool, l ty
 			if err != nil {
 				return err
 			}
+
+			if l.Bare {
+				sub.Info().
+					Msgf("fetching lfs files for %s", types.Green(reponame))
+
+				err = gitc.LFSFetch(filepath.Join(l.Path, reponame))
+				if err != nil {
+					return err
+				}
+			}
 		} else {
 			// fetch to see if there are any unpullable commits, for example a force push
 			err = r.Fetch(&git.FetchOptions{Auth: auth, RemoteName: "origin"})
@@ -431,6 +441,19 @@ func cloneRepository(repo types.Repo, auth transport.AuthMethod, dry bool, l typ
 		}
 
 		err = gitc.Clone(url, filepath.Join(l.Path, repo.Name), l.Bare)
+		if err != nil {
+			return err
+		}
+
+		if l.Bare {
+			sub.Info().
+				Msgf("fetching lfs files for %s", types.Green(repo.Name))
+
+			err = gitc.LFSFetch(filepath.Join(l.Path, repo.Name))
+			if err != nil {
+				return err
+			}
+		}
 	} else {
 		r := &git.Repository{}
 		r, err = git.PlainClone(filepath.Join(l.Path, repo.Name), l.Bare, &git.CloneOptions{


### PR DESCRIPTION
# what

If the repository is bare and LFS is enabled, execute `git lfs fetch --all` command to download all LFS files

# why

Currently, when LFS is enabled in gickup, it relies on the system configuration like this (in `/etc/gitconfig` or `~/.gitconfig`):

```
[filter "lfs"]
	clean = git-lfs clean -- %f
	smudge = git-lfs smudge -- %f
	process = git-lfs filter-process
	required = true
```

But, this works only for non-bare repositories. So in the current implementation it works this way:

- if the repository is non-bare (has a working copy of files), and LFS is enabled in gickup and installed in the system, git will download only files related to the working tree, without history
- if repository is bare (or mirror), it won't download any LFS files at all

With this change, `git lfs fetch --all` will be called explicitly, which will download all known files in the history. **This is the only way to make a full consistent backup with all LFS files.**