### PR TITLE
add zip support for s3 destination

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -276,6 +276,8 @@ destination:
      bucket: your-bucket-name
      accesskey: your-access-key # can be an environment variable, just don't add a $ in front of it
      secretkey: your-secret-key # can be an environment variable, just don't add a $ in front of it
+     token: your-token # can be an environment variable, just don't add a $ in front of it
+     zip: false # if true, will zip the entire git repo into a single zip file and upload that instead
      usessl: true # wheter to use ssl or not
 cron: 0 22 * * * # optional - when cron is not provided, the program runs once and exits.
 # Otherwise, it runs according to the cron schedule.

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -542,6 +542,10 @@
                             "token": {
                                 "type": "string",
                                 "description": "The token to authenticate against the S3 server"
+                            },
+                            "zip": {
+                                "type": "boolean",
+                                "description": "If true, zip the entire Git repo into a single zip file and upload that instead"
                             }
                         },
                         "additionalProperties": false

--- a/types/types.go
+++ b/types/types.go
@@ -543,6 +543,7 @@ type S3Repo struct {
 	Region     string `yaml:"region"`
 	UseSSL     bool   `yaml:"usessl"`
 	Structured bool   `yaml:"structured"`
+	Zip        bool   `yaml:"zip"`
 }
 
 func (s3 S3Repo) GetKey(accessString string) (string, error) {

--- a/zip/zip.go
+++ b/zip/zip.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 )
 
+// Create a Zip file `{repository}.zip` and recursively add the contents of all paths in the `tozip` array to it.
+// Deletes the original contents of `repository` such that only the newly created Zip file remains.
 func Zip(repository string, tozip []string) error {
 	file, err := os.Create(fmt.Sprintf("%s.zip", repository))
 	if err != nil {


### PR DESCRIPTION
- Adds `token` config option to `conf.example.yml` which was forgotten in the last PR. If you want this as a separate PR, please let me know.
- Adds a new `zip` option to the S3 destination. Will zip the entire Git repo before uploading and only upload that zip file.