### PR TITLE
s3 token isn't always needed

### DIFF
--- a/main.go
+++ b/main.go
@@ -243,9 +243,11 @@ func backup(repos []types.Repo, conf *types.Conf) {
 				if err != nil {
 					log.Error().Str("stage", "s3").Str("endpoint", d.Endpoint).Str("bucket", d.Bucket).Msg(err.Error())
 				}
-				d.Token, err = d.GetKey(d.Token)
-				if err != nil {
-					log.Error().Str("stage", "s3").Str("endpoint", d.Endpoint).Str("bucket", d.Bucket).Msg(err.Error())
+				if d.Token != "" {
+					d.Token, err = d.GetKey(d.Token)
+					if err != nil {
+						log.Error().Str("stage", "s3").Str("endpoint", d.Endpoint).Str("bucket", d.Bucket).Msg(err.Error())
+					}
 				}
 
 				if d.Zip {


### PR DESCRIPTION
Not in every S3 solution is the token needed, for example in Minio it isn't necessary to have one.