### PR TITLE
feat(local): Add mirror mode

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -269,6 +269,7 @@ destination:
       zip: true # zips the repository after cloned and removes the repository afterwards
       keep: 5 # only keeps x backups
       bare: true # clone the repositories as bare
+      mirror: true # create mirror clones
       lfs: true # clone lfs repos, !! ATTENTION !! git and git-lfs must be installed on the system!
   s3:
    - endpoint: somewhere:9000 # whatever your s3 endpoint is

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -499,6 +499,10 @@
                                 "type": "boolean",
                                 "description": "clone the repository as a bare repository"
                             },
+                            "mirror": {
+                                "type": "boolean",
+                                "description": "clone the repository as a mirror repository"
+                            },
                             "lfs": {
                                 "type": "boolean",
                                 "description": "uses lfs to clone repositories"

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -22,17 +22,20 @@ func New() (GitCmd, error) {
 	return GitCmd{CMD: "git"}, nil
 }
 
-func (g GitCmd) Clone(url, reponame string, bare bool) error {
+func (g GitCmd) Clone(url, reponame string, bare bool, mirror bool) error {
 	cmd := exec.Command(g.CMD, "clone", url, reponame)
 	if bare {
 		cmd.Args = append(cmd.Args, "--bare")
 	}
+	if mirror {
+		cmd.Args = append(cmd.Args, "--mirror")
+	}
 	return cmd.Run()
 }
 
-func (g GitCmd) Pull(bare bool, repopath string) error {
+func (g GitCmd) Pull(bare bool, mirror bool, repopath string) error {
 	var args = []string{}
-	if bare {
+	if bare || mirror {
 		args = []string{"-C", repopath, "fetch", "--all"}
 	} else {
 		args = []string{"-C", repopath, "pull", "--all"}

--- a/local/local.go
+++ b/local/local.go
@@ -50,7 +50,7 @@ func Locally(repo types.Repo, l types.Local, dry bool) bool {
 		repo.Name = path.Join(repo.Hoster, repo.Owner, repo.Name)
 	}
 
-	if l.Bare {
+	if l.Bare || l.Mirror {
 		repo.Name += ".git"
 	}
 

--- a/local/local.go
+++ b/local/local.go
@@ -329,12 +329,12 @@ func updateRepository(reponame string, auth transport.AuthMethod, dry bool, l ty
 			sub.Info().
 				Msgf("pulling %s", types.Green(reponame))
 
-			err = gitc.Pull(l.Bare, filepath.Join(l.Path, reponame))
+			err = gitc.Pull(l.Bare, l.Mirror, filepath.Join(l.Path, reponame))
 			if err != nil {
 				return err
 			}
 
-			if l.Bare {
+			if l.Bare || l.Mirror {
 				sub.Info().
 					Msgf("fetching lfs files for %s", types.Green(reponame))
 
@@ -355,7 +355,7 @@ func updateRepository(reponame string, auth transport.AuthMethod, dry bool, l ty
 			}
 			sub.Info().
 				Msgf("pulling %s", types.Green(reponame))
-			if !l.Bare {
+			if !l.Bare && !l.Mirror {
 				w, err := r.Worktree()
 				if err != nil {
 					if err == git.NoErrAlreadyUpToDate {
@@ -440,12 +440,12 @@ func cloneRepository(repo types.Repo, auth transport.AuthMethod, dry bool, l typ
 			}
 		}
 
-		err = gitc.Clone(url, filepath.Join(l.Path, repo.Name), l.Bare)
+		err = gitc.Clone(url, filepath.Join(l.Path, repo.Name), l.Bare, l.Mirror)
 		if err != nil {
 			return err
 		}
 
-		if l.Bare {
+		if l.Bare || l.Mirror {
 			sub.Info().
 				Msgf("fetching lfs files for %s", types.Green(repo.Name))
 
@@ -460,6 +460,7 @@ func cloneRepository(repo types.Repo, auth transport.AuthMethod, dry bool, l typ
 			URL:          url,
 			Auth:         auth,
 			SingleBranch: false,
+			Mirror:       l.Mirror,
 		})
 		if err != nil {
 			return err
@@ -548,7 +549,7 @@ func TempClone(repo types.Repo, tempdir string) (*git.Repository, error) {
 			repo.URL = strings.Replace(repo.URL, "https://", fmt.Sprintf("https://xyz:%s@", repo.Token), -1)
 		}
 
-		err = gitc.Clone(repo.URL, tempdir, false)
+		err = gitc.Clone(repo.URL, tempdir, false, false)
 		if err != nil {
 			return nil, err
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -47,6 +47,7 @@ func (dest Destination) Count() int {
 // Local TODO.
 type Local struct {
 	Bare       bool   `yaml:"bare"`
+	Mirror     bool   `yaml:"mirror" default:"false"`
 	Path       string `yaml:"path"`
 	Structured bool   `yaml:"structured"`
 	Zip        bool   `yaml:"zip"`


### PR DESCRIPTION
# what

This PR adds support for cloning in the mirror mode (`git clone --mirror`)

The config will be slightly different. For bare repositories:

```ini
[core]
	bare = true
[remote "origin"]
	url = git@github.com:....git
	fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
	remote = origin
	merge = refs/heads/master
```

For mirror:

```ini
[core]
	bare = true
[remote "origin"]
	url = git@github.com:....git
	fetch = +refs/*:refs/*
	mirror = true
```

# why

Mirror mode can be considered a better alternative for bare repositories to use as backups, as it is easier and more convenient

# docs

- https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--mirrorcode
- https://graphite.dev/guides/git-clone-bare-mirror