### PR TITLE
Improve error output. Make empty-remote a warning instead of an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,6 +225,11 @@ func backup(repos []types.Repo, conf *types.Conf) {
 							Str("stage", "s3").
 							Str("url", r.URL).
 							Msg(err.Error())
+					} else if err.Error() == "remote repository is empty" {
+						log.Warn().
+							Str("repo", r.Name).
+							Msgf("%s - Skipping backup", err.Error())
+						continue
 					} else {
 						log.Error().
 							Str("stage", "tempclone").
@@ -881,6 +886,10 @@ func runBackup(conf *types.Conf, num int) {
 				log.Warn().Str("push", "apprise").Err(err).Msg("couldn't send message")
 			}
 		}
+	}
+	exitCode := logger.GetExitCode()
+	if exitCode != 0 {
+		log.Warn().Msgf("Encountered at least one error during the run. Check the logs. Exiting with status=%d", exitCode)
 	}
 
 	log.Info().

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cooperspencer/gickup/s3"
 	"github.com/cooperspencer/gickup/sourcehut"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/go-cmp/cmp"
 	"github.com/minio/minio-go/v7"
 
@@ -225,7 +226,7 @@ func backup(repos []types.Repo, conf *types.Conf) {
 							Str("stage", "s3").
 							Str("url", r.URL).
 							Msg(err.Error())
-					} else if err.Error() == "remote repository is empty" {
+					} else if err == transport.ErrEmptyRemoteRepository {
 						log.Warn().
 							Str("repo", r.Name).
 							Msgf("%s - Skipping backup", err.Error())


### PR DESCRIPTION
Makes an empty remote a warning rather than an error, consistent with the `Local` backup dest.

Error string unfortunately has to be hard-coded since [the error itself](https://pkg.go.dev/github.com/go-git/go-git/v5/plumbing/transport#pkg-variables) is not exported.
