### PR TITLE
Make S3 backups bare

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -521,6 +521,14 @@ func VerifyHost(host string, remote net.Addr, key gossh.PublicKey) error {
 }
 
 func TempClone(repo types.Repo, tempdir string) (*git.Repository, error) {
+	return tempCloneBase(repo, tempdir, false)
+}
+
+func TempCloneBare(repo types.Repo, tempdir string) (*git.Repository, error) {
+	return tempCloneBase(repo, tempdir, true)
+}
+
+func tempCloneBase(repo types.Repo, tempdir string, isBare bool) (*git.Repository, error) {
 	var auth transport.AuthMethod
 	if repo.Token != "" {
 		if repo.NoTokenUser {
@@ -549,7 +557,7 @@ func TempClone(repo types.Repo, tempdir string) (*git.Repository, error) {
 			repo.URL = strings.Replace(repo.URL, "https://", fmt.Sprintf("https://xyz:%s@", repo.Token), -1)
 		}
 
-		err = gitc.Clone(repo.URL, tempdir, false, false)
+		err = gitc.Clone(repo.URL, tempdir, isBare, false)
 		if err != nil {
 			return nil, err
 		}
@@ -602,7 +610,7 @@ func TempClone(repo types.Repo, tempdir string) (*git.Repository, error) {
 
 		return r, err
 	} else {
-		r, err := git.PlainClone(tempdir, false, &git.CloneOptions{
+		r, err := git.PlainClone(tempdir, isBare, &git.CloneOptions{
 			URL:          repo.URL,
 			Auth:         auth,
 			SingleBranch: false,

--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func backup(repos []types.Repo, conf *types.Conf) {
 
 				defer os.RemoveAll(tempdir)
 				tempClonePath := path.Join(tempdir, r.Name)
-				_, err = local.TempClone(r, tempClonePath)
+				_, err = local.TempCloneBare(r, tempClonePath)
 				if err != nil {
 					if err == git.NoErrAlreadyUpToDate {
 						log.Info().


### PR DESCRIPTION
Every other destination is Git-based, meaning pushing all refs (which is what's happening) will ensure all remote branches are copied and backed up.

For the S3 destination, this is not the case since the repo is pushed as-is. This means an S3 backup will only have the default branch checked out. This is fixed by backing up a bare clone.

Maybe add to the S3-dest docs that you can restore a bare clone into a normal Git repo with `git clone /path/to/bare /path/to/normal`?