### PR TITLE
add backup creation date directory in s3

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -281,7 +281,7 @@ destination:
      zip: false # if true, will zip the entire git repo into a single zip file and upload that instead
      usessl: true # wheter to use ssl or not
      storageclass: "" # storage class for all repos to be uploaded to this S3 bucket. E.g. for AWS: STANDARD, STANDARD_IA, GLACIER, etc.
-     datecreate: false # if true, gickup will create a directory for backup with the creation date
+     datecreatedir: false # if true, gickup will create a directory for backup with the creation date
 cron: 0 22 * * * # optional - when cron is not provided, the program runs once and exits.
 # Otherwise, it runs according to the cron schedule.
 # See timezone commentary in docker-compose.yml for making sure this container runs

--- a/conf.example.yml
+++ b/conf.example.yml
@@ -281,6 +281,7 @@ destination:
      zip: false # if true, will zip the entire git repo into a single zip file and upload that instead
      usessl: true # wheter to use ssl or not
      storageclass: "" # storage class for all repos to be uploaded to this S3 bucket. E.g. for AWS: STANDARD, STANDARD_IA, GLACIER, etc.
+     datecreate: false # if true, gickup will create a directory for backup with the creation date
 cron: 0 22 * * * # optional - when cron is not provided, the program runs once and exits.
 # Otherwise, it runs according to the cron schedule.
 # See timezone commentary in docker-compose.yml for making sure this container runs

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -554,6 +554,10 @@
                             "storageclass": {
                                 "type": "string",
                                 "description": "Storage class applied to all repos uploaded to this S3 bucket (optional)"
+                            },
+                            "datecreate": {
+                                "type": "boolean",
+                                "description": "If true, gickup will create a directory for backup with the creation date"
                             }
                         },
                         "additionalProperties": false

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -555,7 +555,7 @@
                                 "type": "string",
                                 "description": "Storage class applied to all repos uploaded to this S3 bucket (optional)"
                             },
-                            "datecreate": {
+                            "datecreatedir": {
                                 "type": "boolean",
                                 "description": "If true, gickup will create a directory for backup with the creation date"
                             }

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func backup(repos []types.Repo, conf *types.Conf) {
 					r.Name = path.Join(r.Hoster, r.Owner, r.Name)
 				}
 
-				if d.DateCreate {
+				if d.DateCreateDir {
 					r.Name = currentDateDir + r.Name
 				}
 

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func substituteHomeForTildeInPath(path string) string {
 
 func backup(repos []types.Repo, conf *types.Conf) {
 	checkedpath := false
+	currentDateDir := time.Now().Format("2006-01-02") + "/"
 
 	for _, r := range repos {
 		log.Info().
@@ -215,6 +216,10 @@ func backup(repos []types.Repo, conf *types.Conf) {
 
 				if d.Structured {
 					r.Name = path.Join(r.Hoster, r.Owner, r.Name)
+				}
+
+				if d.DateCreate {
+					r.Name = currentDateDir + r.Name
 				}
 
 				defer os.RemoveAll(tempdir)

--- a/types/types.go
+++ b/types/types.go
@@ -555,6 +555,7 @@ type S3Repo struct {
 	Structured   bool   `yaml:"structured"`
 	Zip          bool   `yaml:"zip"`
 	StorageClass string `yaml:"storageclass"`
+	DateCreate   bool   `yaml:"datecreate"`
 }
 
 func (s3 S3Repo) GetKey(accessString string) (string, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -545,17 +545,17 @@ func StatRemote(remoteURL, sshURL string, repo GenRepo) bool {
 }
 
 type S3Repo struct {
-	Bucket       string `yaml:"bucket"`
-	Endpoint     string `yaml:"endpoint"`
-	AccessKey    string `yaml:"accesskey"`
-	SecretKey    string `yaml:"secretkey"`
-	Token        string `yaml:"token"`
-	Region       string `yaml:"region"`
-	UseSSL       bool   `yaml:"usessl"`
-	Structured   bool   `yaml:"structured"`
-	Zip          bool   `yaml:"zip"`
-	StorageClass string `yaml:"storageclass"`
-	DateCreate   bool   `yaml:"datecreate"`
+	Bucket        string `yaml:"bucket"`
+	Endpoint      string `yaml:"endpoint"`
+	AccessKey     string `yaml:"accesskey"`
+	SecretKey     string `yaml:"secretkey"`
+	Token         string `yaml:"token"`
+	Region        string `yaml:"region"`
+	UseSSL        bool   `yaml:"usessl"`
+	Structured    bool   `yaml:"structured"`
+	Zip           bool   `yaml:"zip"`
+	StorageClass  string `yaml:"storageclass"`
+	DateCreateDir bool   `yaml:"datecreatedir"`
 }
 
 func (s3 S3Repo) GetKey(accessString string) (string, error) {


### PR DESCRIPTION
This change will add "datecreatedir" boolean argument in conf.yml file in s3 section. If "datecreatedir" is true, gickup will create a directory for backup with the creation date in s3 bucket.
Example: current date is 2025-04-26. So the actual location of backup in s3 bucket will be 2025-04-26/gitea.local/organization/reponame (structured: true) or 2025-04-26/reponame (structured: false)