### PR TITLE
S3 dest: Tag backup objects with original repo's URL

### DIFF
--- a/conf.example.yml
+++ b/conf.example.yml
@@ -281,6 +281,7 @@ destination:
      zip: false # if true, will zip the entire git repo into a single zip file and upload that instead
      usessl: true # wheter to use ssl or not
      storageclass: "" # storage class for all repos to be uploaded to this S3 bucket. E.g. for AWS: STANDARD, STANDARD_IA, GLACIER, etc.
+     src_repo_url_tag_key: "" # if set, tag each uploaded object with this key and the source repo URL as value. Leave unset to disable tagging.
      datecreatedir: false # if true, gickup will create a directory for backup with the creation date
   azureblob:
     - url: https://yourstorageaccount.blob.core.windows.net # blob storage endpoint for your storage account, can be a SAS url

--- a/gickup_spec.json
+++ b/gickup_spec.json
@@ -555,6 +555,10 @@
                                 "type": "string",
                                 "description": "Storage class applied to all repos uploaded to this S3 bucket (optional)"
                             },
+                            "src_repo_url_tag_key": {
+                                "type": "string",
+                                "description": "If set, tag each uploaded object with this key and the source repo URL as value"
+                            },
                             "datecreatedir": {
                                 "type": "boolean",
                                 "description": "If true, gickup will create a directory for backup with the creation date"

--- a/main.go
+++ b/main.go
@@ -277,6 +277,9 @@ func backup(repos []types.Repo, conf *types.Conf) {
 				}
 				err = s3.UploadDirToS3(tempdir, d, &minio.PutObjectOptions{
 					StorageClass: d.StorageClass,
+					UserTags: map[string]string{
+						"url": r.URL,
+					},
 				})
 				if err != nil {
 					log.Error().Str("stage", "s3").Str("endpoint", d.Endpoint).Str("bucket", d.Bucket).Msg(err.Error())

--- a/main.go
+++ b/main.go
@@ -275,12 +275,15 @@ func backup(repos []types.Repo, conf *types.Conf) {
 						continue
 					}
 				}
-				err = s3.UploadDirToS3(tempdir, d, &minio.PutObjectOptions{
+				s3opts := &minio.PutObjectOptions{
 					StorageClass: d.StorageClass,
-					UserTags: map[string]string{
-						"url": r.URL,
-					},
-				})
+				}
+				if d.SrcRepoUrlTagKey != nil {
+					s3opts.UserTags = map[string]string{
+						*d.SrcRepoUrlTagKey: r.URL,
+					}
+				}
+				err = s3.UploadDirToS3(tempdir, d, s3opts)
 				if err != nil {
 					log.Error().Str("stage", "s3").Str("endpoint", d.Endpoint).Str("bucket", d.Bucket).Msg(err.Error())
 				}

--- a/types/types.go
+++ b/types/types.go
@@ -559,8 +559,9 @@ type S3Repo struct {
 	UseSSL        bool   `yaml:"usessl"`
 	Structured    bool   `yaml:"structured"`
 	Zip           bool   `yaml:"zip"`
-	StorageClass  string `yaml:"storageclass"`
-	DateCreateDir bool   `yaml:"datecreatedir"`
+	StorageClass     string  `yaml:"storageclass"`
+	DateCreateDir    bool    `yaml:"datecreatedir"`
+	SrcRepoUrlTagKey *string `yaml:"src_repo_url_tag_key"`
 }
 
 func (s3 S3Repo) GetKey(accessString string) (string, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -550,18 +550,18 @@ func StatRemote(remoteURL, sshURL string, repo GenRepo) bool {
 }
 
 type S3Repo struct {
-	Bucket        string `yaml:"bucket"`
-	Endpoint      string `yaml:"endpoint"`
-	AccessKey     string `yaml:"accesskey"`
-	SecretKey     string `yaml:"secretkey"`
-	Token         string `yaml:"token"`
-	Region        string `yaml:"region"`
-	UseSSL        bool   `yaml:"usessl"`
-	Structured    bool   `yaml:"structured"`
-	Zip           bool   `yaml:"zip"`
-	StorageClass     string  `yaml:"storageclass"`
-	DateCreateDir    bool    `yaml:"datecreatedir"`
-	SrcRepoUrlTagKey *string `yaml:"src_repo_url_tag_key"`
+	Bucket           string `yaml:"bucket"`
+	Endpoint         string `yaml:"endpoint"`
+	AccessKey        string `yaml:"accesskey"`
+	SecretKey        string `yaml:"secretkey"`
+	Token            string `yaml:"token"`
+	Region           string `yaml:"region"`
+	UseSSL           bool   `yaml:"usessl"`
+	Structured       bool   `yaml:"structured"`
+	Zip              bool   `yaml:"zip"`
+	StorageClass     string `yaml:"storageclass"`
+	DateCreateDir    bool   `yaml:"datecreatedir"`
+	SrcRepoUrlTagKey *string`yaml:"src_repo_url_tag_key"`
 }
 
 func (s3 S3Repo) GetKey(accessString string) (string, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -550,18 +550,18 @@ func StatRemote(remoteURL, sshURL string, repo GenRepo) bool {
 }
 
 type S3Repo struct {
-	Bucket           string `yaml:"bucket"`
-	Endpoint         string `yaml:"endpoint"`
-	AccessKey        string `yaml:"accesskey"`
-	SecretKey        string `yaml:"secretkey"`
-	Token            string `yaml:"token"`
-	Region           string `yaml:"region"`
-	UseSSL           bool   `yaml:"usessl"`
-	Structured       bool   `yaml:"structured"`
-	Zip              bool   `yaml:"zip"`
-	StorageClass     string `yaml:"storageclass"`
-	DateCreateDir    bool   `yaml:"datecreatedir"`
-	SrcRepoUrlTagKey *string`yaml:"src_repo_url_tag_key"`
+	Bucket           string  `yaml:"bucket"`
+	Endpoint         string  `yaml:"endpoint"`
+	AccessKey        string  `yaml:"accesskey"`
+	SecretKey        string  `yaml:"secretkey"`
+	Token            string  `yaml:"token"`
+	Region           string  `yaml:"region"`
+	UseSSL           bool    `yaml:"usessl"`
+	Structured       bool    `yaml:"structured"`
+	Zip              bool    `yaml:"zip"`
+	StorageClass     string  `yaml:"storageclass"`
+	DateCreateDir    bool    `yaml:"datecreatedir"`
+	SrcRepoUrlTagKey *string `yaml:"src_repo_url_tag_key"`
 }
 
 func (s3 S3Repo) GetKey(accessString string) (string, error) {


### PR DESCRIPTION
Linking an S3 backup back to its original source repo can be a bit tricky. So, this adds the option to tag S3 objects with the original repo source URL. The tag key for this is configurable.