### PR TITLE
Fix unintentional data loss when zip is false and keep greater than or one

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -283,6 +283,7 @@ func Locally(repo types.Repo, l types.Local, dry bool) bool {
 					sub.Warn().
 						Str("repo", repo.Name).
 						Msgf("couldn't parse timestamp! %s", types.Red(file.Name()))
+					continue
 				}
 				if l.Zip && !strings.HasSuffix(file.Name(), ".zip") {
 					continue


### PR DESCRIPTION
See https://github.com/cooperspencer/gickup/issues/398 for more information on the logic error and the potential data loss.