### PR TITLE
fix: gitlab organization filtering not including nested subgroups

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -209,7 +209,11 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 					Msg(err.Error())
 				continue
 			}
-			subgroups, _, err := client.Groups.ListSubGroups(group.ID, &gitlab.ListSubGroupsOptions{})
+
+			subgroups, err := gitlab.ScanAndCollect(func(p gitlab.PaginationOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
+				return client.Groups.ListDescendantGroups(group.ID, &gitlab.ListDescendantGroupsOptions{}, p)
+			})
+
 			for _, sub := range subgroups {
 				includeorgs[sub.FullPath] = true
 			}
@@ -222,7 +226,11 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 					Msg(err.Error())
 				continue
 			}
-			subgroups, _, err := client.Groups.ListSubGroups(group.ID, &gitlab.ListSubGroupsOptions{})
+
+			subgroups, err := gitlab.ScanAndCollect(func(p gitlab.PaginationOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
+				return client.Groups.ListDescendantGroups(group.ID, &gitlab.ListDescendantGroupsOptions{}, p)
+			})
+
 			for _, sub := range subgroups {
 				excludeorgs[sub.FullPath] = true
 			}


### PR DESCRIPTION
Gitlab supports nesting subgroups up to 20 levels deep. However, these two filters were actually applied to projects in the provided organization/group as well as projects in any immediate subgroup, but not to projects in more deeply nested subgroups. Presumably, the original intention of these filters was that the entire organization/group would be either included or excluded, not only projects in the group and its immediate subgroups.

Fix by using ListDescendantGroups() to get all descendant/nested groups. Also, use gitlab.ScanAndCollect() to handle paginated results.