### PR TITLE
Fix 415 pruning old folders does count non repo folders

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -289,36 +289,38 @@ func pruneOldBackups(parentdir string, repoName string, l types.Local) error {
 		return err
 	}
 
-	keep := []string{}
+	// A backup generation is the "<timestamp>" directory plus "<timestamp>.<something>"
+	// (like "<timestamp>.issues")
+	// They are grouped by their timestamp so that together they only count as one backup against l.Keep.
+	generations := map[int64][]string{}
 	for _, file := range files {
-		fname := file.Name()
-		if l.Zip {
-			fname = strings.TrimSuffix(file.Name(), ".zip")
-		}
+		stamp, _, _ := strings.Cut(file.Name(), ".")
 
-		fname = strings.TrimSuffix(fname, ".issues")
-
-		_, err := strconv.ParseInt(fname, 10, 64)
+		ts, err := strconv.ParseInt(stamp, 10, 64)
 		if err != nil {
 			sub.Warn().
 				Str("repo", repoName).
 				Msgf("couldn't parse timestamp! %s", types.Red(file.Name()))
 			continue
 		}
-		if l.Zip && !strings.HasSuffix(file.Name(), ".zip") {
-			continue
-		}
-		keep = append(keep, file.Name())
+		generations[ts] = append(generations[ts], file.Name())
 	}
 
-	sort.Sort(sort.Reverse(sort.StringSlice(keep)))
+	if len(generations) <= l.Keep {
+		return nil
+	}
 
-	if len(keep) > l.Keep {
-		toremove := keep[l.Keep:]
-		for _, file := range toremove {
+	stamps := make([]int64, 0, len(generations))
+	for ts := range generations {
+		stamps = append(stamps, ts)
+	}
+	sort.Slice(stamps, func(i, j int) bool { return stamps[i] > stamps[j] })
+
+	for _, ts := range stamps[l.Keep:] {
+		for _, file := range generations[ts] {
 			sub.Info().
-				Msgf("removing %s", types.Red(path.Join(parentdir, file)))
-			err := os.RemoveAll(path.Join(parentdir, file))
+				Msgf("removing %s", types.Red(filepath.Join(parentdir, file)))
+			err := os.RemoveAll(filepath.Join(parentdir, file))
 			if err != nil {
 				sub.Warn().
 					Str("repo", repoName).Msg(err.Error())

--- a/local/local.go
+++ b/local/local.go
@@ -268,50 +268,11 @@ func Locally(repo types.Repo, l types.Local, dry bool) bool {
 		}
 
 		if l.Keep > 0 {
-			parentdir := filepath.Dir(filepath.Join(l.Path, repo.Name))
-			files, err := os.ReadDir(parentdir)
-			if err != nil {
+			if err := pruneOldBackups(filepath.Dir(filepath.Join(l.Path, repo.Name)), repo.Name, l); err != nil {
 				sub.Warn().
 					Str("repo", repo.Name).Msg(err.Error())
 
 				return false
-			}
-
-			keep := []string{}
-			for _, file := range files {
-				fname := file.Name()
-				if l.Zip {
-					fname = strings.TrimSuffix(file.Name(), ".zip")
-				}
-
-				fname = strings.TrimSuffix(fname, ".issues")
-
-				_, err := strconv.ParseInt(fname, 10, 64)
-				if err != nil {
-					sub.Warn().
-						Str("repo", repo.Name).
-						Msgf("couldn't parse timestamp! %s", types.Red(file.Name()))
-					continue
-				}
-				if l.Zip && !strings.HasSuffix(file.Name(), ".zip") {
-					continue
-				}
-				keep = append(keep, file.Name())
-			}
-
-			sort.Sort(sort.Reverse(sort.StringSlice(keep)))
-
-			if len(keep) > l.Keep {
-				toremove := keep[l.Keep:]
-				for _, file := range toremove {
-					sub.Info().
-						Msgf("removing %s", types.Red(path.Join(parentdir, file)))
-					err := os.RemoveAll(path.Join(parentdir, file))
-					if err != nil {
-						sub.Warn().
-							Str("repo", repo.Name).Msg(err.Error())
-					}
-				}
 			}
 		}
 
@@ -319,6 +280,53 @@ func Locally(repo types.Repo, l types.Local, dry bool) bool {
 	}
 
 	return true
+}
+
+// pruneOldBackups enforces l.Keep by removing the oldest timestamped backups
+func pruneOldBackups(parentdir string, repoName string, l types.Local) error {
+	files, err := os.ReadDir(parentdir)
+	if err != nil {
+		return err
+	}
+
+	keep := []string{}
+	for _, file := range files {
+		fname := file.Name()
+		if l.Zip {
+			fname = strings.TrimSuffix(file.Name(), ".zip")
+		}
+
+		fname = strings.TrimSuffix(fname, ".issues")
+
+		_, err := strconv.ParseInt(fname, 10, 64)
+		if err != nil {
+			sub.Warn().
+				Str("repo", repoName).
+				Msgf("couldn't parse timestamp! %s", types.Red(file.Name()))
+			continue
+		}
+		if l.Zip && !strings.HasSuffix(file.Name(), ".zip") {
+			continue
+		}
+		keep = append(keep, file.Name())
+	}
+
+	sort.Sort(sort.Reverse(sort.StringSlice(keep)))
+
+	if len(keep) > l.Keep {
+		toremove := keep[l.Keep:]
+		for _, file := range toremove {
+			sub.Info().
+				Msgf("removing %s", types.Red(path.Join(parentdir, file)))
+			err := os.RemoveAll(path.Join(parentdir, file))
+			if err != nil {
+				sub.Warn().
+					Str("repo", repoName).Msg(err.Error())
+			}
+		}
+	}
+
+	return nil
 }
 
 func updateRepository(reponame string, auth transport.AuthMethod, dry bool, l types.Local) error {

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -37,6 +37,8 @@ func runPrune(t *testing.T, backups []string, keep int) []string {
 }
 
 func TestPruneKeepsNewestBackup(t *testing.T) {
+	t.Parallel()
+
 	remaining := runPrune(t, []string{"1785061240", "1785115104"}, 1)
 
 	want := []string{"1785115104"}
@@ -46,6 +48,8 @@ func TestPruneKeepsNewestBackup(t *testing.T) {
 }
 
 func TestPruneKeepsIssuesDirWithItsBackup(t *testing.T) {
+	t.Parallel()
+
 	remaining := runPrune(t,
 		[]string{"1785061241", "1785061241.issues", "1785115111", "1785115111.issues"}, 1)
 
@@ -55,7 +59,9 @@ func TestPruneKeepsIssuesDirWithItsBackup(t *testing.T) {
 	}
 }
 
-func TestPruneKeepsOtherDirectorys(t *testing.T) {
+func TestPruneKeepsOtherDirectories(t *testing.T) {
+	t.Parallel()
+
 	remaining := runPrune(t,
 		[]string{"1785061241", "1785061241.issues", "dummy", "dummy.issue", "1785061241x.dummy", "1785115111", "1785115111.issues"}, 1)
 
@@ -65,11 +71,25 @@ func TestPruneKeepsOtherDirectorys(t *testing.T) {
 	}
 }
 
-func TestPruneDeletesOtherTimestampedDirectorys(t *testing.T) {
+func TestPruneDeletesOtherTimestampedDirectories(t *testing.T) {
+	t.Parallel()
+
 	remaining := runPrune(t,
 		[]string{"1785061241", "1785061241.issues", "1785061241.dummy", "1785115111", "1785115111.issues"}, 1)
 
 	want := []string{"1785115111", "1785115111.issues"}
+	if !reflect.DeepEqual(remaining, want) {
+		t.Fatalf("remaining = %v, want %v", remaining, want)
+	}
+}
+
+func TestPruneKeepsMultipleGenerations(t *testing.T) {
+	t.Parallel()
+
+	remaining := runPrune(t,
+		[]string{"1785000000", "1785000000.issues", "1785061241", "1785061241.issues", "1785115111", "1785115111.issues"}, 2)
+
+	want := []string{"1785061241", "1785061241.issues", "1785115111", "1785115111.issues"}
 	if !reflect.DeepEqual(remaining, want) {
 		t.Fatalf("remaining = %v, want %v", remaining, want)
 	}

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1,11 +1,79 @@
 package local
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/cooperspencer/gickup/types"
 )
+
+func runPrune(t *testing.T, backups []string, keep int) []string {
+	t.Helper()
+
+	parentdir := t.TempDir()
+	for _, d := range backups {
+		if err := os.Mkdir(filepath.Join(parentdir, d), 0o777); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := pruneOldBackups(parentdir, "test/repo", types.Local{Keep: keep}); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := os.ReadDir(parentdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remaining := []string{}
+	for _, f := range files {
+		remaining = append(remaining, f.Name())
+	}
+
+	return remaining
+}
+
+func TestPruneKeepsNewestBackup(t *testing.T) {
+	remaining := runPrune(t, []string{"1785061240", "1785115104"}, 1)
+
+	want := []string{"1785115104"}
+	if !reflect.DeepEqual(remaining, want) {
+		t.Fatalf("remaining = %v, want %v", remaining, want)
+	}
+}
+
+func TestPruneKeepsIssuesDirWithItsBackup(t *testing.T) {
+	remaining := runPrune(t,
+		[]string{"1785061241", "1785061241.issues", "1785115111", "1785115111.issues"}, 1)
+
+	want := []string{"1785115111", "1785115111.issues"}
+	if !reflect.DeepEqual(remaining, want) {
+		t.Fatalf("remaining = %v, want %v", remaining, want)
+	}
+}
+
+func TestPruneKeepsOtherDirectorys(t *testing.T) {
+	remaining := runPrune(t,
+		[]string{"1785061241", "1785061241.issues", "dummy", "dummy.issue", "1785061241x.dummy", "1785115111", "1785115111.issues"}, 1)
+
+	want := []string{"1785061241x.dummy", "1785115111", "1785115111.issues", "dummy", "dummy.issue"}
+	if !reflect.DeepEqual(remaining, want) {
+		t.Fatalf("remaining = %v, want %v", remaining, want)
+	}
+}
+
+func TestPruneDeletesOtherTimestampedDirectorys(t *testing.T) {
+	remaining := runPrune(t,
+		[]string{"1785061241", "1785061241.issues", "1785061241.dummy", "1785115111", "1785115111.issues"}, 1)
+
+	want := []string{"1785115111", "1785115111.issues"}
+	if !reflect.DeepEqual(remaining, want) {
+		t.Fatalf("remaining = %v, want %v", remaining, want)
+	}
+}
 
 func TestRandomStringLengthAndCharset(t *testing.T) {
 	t.Parallel()

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -95,6 +95,17 @@ func TestPruneKeepsMultipleGenerations(t *testing.T) {
 	}
 }
 
+func TestPruneKeepsEverythingBelowKeepCount(t *testing.T) {
+	t.Parallel()
+
+	remaining := runPrune(t, []string{"1785115111", "1785115111.issues"}, 2)
+
+	want := []string{"1785115111", "1785115111.issues"}
+	if !reflect.DeepEqual(remaining, want) {
+		t.Fatalf("remaining = %v, want %v", remaining, want)
+	}
+}
+
 func TestRandomStringLengthAndCharset(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This fixes #415 - the problem is that the old versions (generations) do count every folder as one generation, so the folder 1234567890 and the folder 1234567890.issues are counted as two generations - which they are not, they are only two entries for the same 1234567890 timestamp generation.

This PR first refactored the prune logic to make it testable, then added tests and then made the tests pass by changing the prune logic (tdd style).

The logic has been changed so that ALL ENTRIES (Folders or Files) with the name schema <timestamp> or <timestamp>.<other> are counted to one generation. That means the 1234567890 folder together with its 1234567890.issues folder will be deleted as it should be.
This also removes the need for the special logic for `.zip` files.
The side effect is that all other 1234567890.mycoolfolder or 1234567890.doesntbelonghere will also be deleted. This is intentional as I don't think that any human will be manually adding a folder with the exact timestamp of a generation - and if he does that he maybe intends it to be deleted along with the generation when its keep count is over.
Note on the side effect: A timestamp can be everything which is all numeric. So the folder `500.html` or `666` will be regarded as a generation and deleted.

Other entries which are not looking like a timestamp (all numbers) or timestamp<dot> anything won't be touched.
That means:
Deleting:
```
123
123.dummy
500.html
666
```

Ignoring:
```
123dummy
dummy
```

Another side note:
A manual entry with a timestamp like `99999999999` will also be a generation and will always be the most recent to keep.
So this leads to the wrong generation being deleted!
Until the timestamp 99999999999 will be old enough in the year 5138 :-)

