### PR TITLE
fix GitLab mirroring visibility, URL parsing, and ref pushes

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -16,6 +16,20 @@ import (
 
 var sub zerolog.Logger
 
+func getRepoVisibility(visibility string, private bool) gitlab.VisibilityValue {
+	switch strings.ToLower(strings.TrimSpace(visibility)) {
+	case "private":
+		return gitlab.PrivateVisibility
+	case "public":
+		return gitlab.PublicVisibility
+	default:
+		if private {
+			return gitlab.PrivateVisibility
+		}
+		return gitlab.PublicVisibility
+	}
+}
+
 // Backup TODO.
 func Backup(r types.Repo, d types.GenRepo, dry bool) bool {
 	var gitlabclient *gitlab.Client
@@ -69,13 +83,7 @@ func Backup(r types.Repo, d types.GenRepo, dry bool) bool {
 			splittedurl[0], r.Owner, r.Token, splittedurl[1])
 	}
 
-	var visibility gitlab.VisibilityValue
-
-	if r.Private {
-		visibility = gitlab.PrivateVisibility
-	} else {
-		visibility = gitlab.PublicVisibility
-	}
+	visibility := getRepoVisibility(d.Visibility.Repositories, r.Private)
 
 	opts := &gitlab.CreateProjectOptions{
 		Mirror:      &True,
@@ -586,11 +594,7 @@ func GetIssues(repo *gitlab.Project, client *gitlab.Client, conf types.GenRepo) 
 
 // GetOrCreate Get or create a repository
 func GetOrCreate(destination types.GenRepo, repo types.Repo) (string, error) {
-	visibility := gitlab.PublicVisibility
-
-	if repo.Private {
-		visibility = gitlab.PrivateVisibility
-	}
+	visibility := getRepoVisibility(destination.Visibility.Repositories, repo.Private)
 
 	sub = logger.CreateSubLogger("stage", "gitlab", "url", destination.URL)
 

--- a/gitlab/gitlab_test.go
+++ b/gitlab/gitlab_test.go
@@ -1,0 +1,31 @@
+package gitlab
+
+import (
+	"testing"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestGetRepoVisibility(t *testing.T) {
+	tests := []struct {
+		name          string
+		configured    string
+		sourcePrivate bool
+		want          gitlab.VisibilityValue
+	}{
+		{name: "private overrides public source", configured: "private", want: gitlab.PrivateVisibility},
+		{name: "public overrides private source", configured: "public", sourcePrivate: true, want: gitlab.PublicVisibility},
+		{name: "empty follows private source", sourcePrivate: true, want: gitlab.PrivateVisibility},
+		{name: "empty follows public source", want: gitlab.PublicVisibility},
+		{name: "source follows private source", configured: "source", sourcePrivate: true, want: gitlab.PrivateVisibility},
+		{name: "source follows public source", configured: "source", want: gitlab.PublicVisibility},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := getRepoVisibility(test.configured, test.sourcePrivate); got != test.want {
+				t.Fatalf("getRepoVisibility(%q, %t) = %q, want %q", test.configured, test.sourcePrivate, got, test.want)
+			}
+		})
+	}
+}

--- a/local/local.go
+++ b/local/local.go
@@ -724,11 +724,43 @@ func CreateRemotePush(repo *git.Repository, destination types.GenRepo, url strin
 
 	err = repo.Push(&pushoptions)
 	if err == nil || errors.Is(err, git.NoErrAlreadyUpToDate) {
-		pushoptions = git.PushOptions{Force: destination.Force, Auth: auth, RemoteName: remote.Config().Name, RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*", "refs/tags/*:refs/tags/*"}}
+		refspecs, err := getPushRefSpecs(repo, headref.Name())
+		if err != nil {
+			return err
+		}
 
-		return repo.Push(&pushoptions)
+		var pushErrors []error
+		// Keep valid refs moving when a destination hook rejects one branch or tag.
+		for _, refspec := range refspecs {
+			pushoptions.RefSpecs = []config.RefSpec{refspec}
+			err = repo.Push(&pushoptions)
+			if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+				pushErrors = append(pushErrors, err)
+			}
+		}
+
+		return errors.Join(pushErrors...)
 	}
 	return err
+}
+
+func getPushRefSpecs(repo *git.Repository, skip plumbing.ReferenceName) ([]config.RefSpec, error) {
+	refs, err := repo.References()
+	if err != nil {
+		return nil, err
+	}
+
+	refspecs := []config.RefSpec{}
+	err = refs.ForEach(func(ref *plumbing.Reference) error {
+		name := ref.Name()
+		if name == skip || (!name.IsBranch() && !name.IsTag()) {
+			return nil
+		}
+
+		refspecs = append(refspecs, config.RefSpec(fmt.Sprintf("%s:%s", name, name)))
+		return nil
+	})
+	return refspecs, err
 }
 
 func RandomString(length int) string {

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/cooperspencer/gickup/types"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 func runPrune(t *testing.T, backups []string, keep int) []string {
@@ -178,5 +181,48 @@ func TestTokenAuth_WithTokenUser(t *testing.T) {
 	}
 	if got.Password != "mytoken" {
 		t.Errorf("Password = %q, want %q", got.Password, "mytoken")
+	}
+}
+
+func TestGetPushRefSpecs(t *testing.T) {
+	t.Parallel()
+
+	repo, err := git.Init(memory.NewStorage(), nil)
+	if err != nil {
+		t.Fatalf("init repository: %v", err)
+	}
+
+	hash := plumbing.NewHash("1111111111111111111111111111111111111111")
+	for _, name := range []plumbing.ReferenceName{
+		plumbing.NewBranchReferenceName("master"),
+		plumbing.NewBranchReferenceName("feature"),
+		plumbing.NewTagReferenceName("v1.0.0"),
+		plumbing.NewRemoteReferenceName("origin", "feature"),
+	} {
+		if err := repo.Storer.SetReference(plumbing.NewHashReference(name, hash)); err != nil {
+			t.Fatalf("set reference %s: %v", name, err)
+		}
+	}
+
+	refspecs, err := getPushRefSpecs(repo, plumbing.NewBranchReferenceName("master"))
+	if err != nil {
+		t.Fatalf("getPushRefSpecs() error: %v", err)
+	}
+
+	want := map[string]bool{
+		"refs/heads/feature:refs/heads/feature": false,
+		"refs/tags/v1.0.0:refs/tags/v1.0.0":     false,
+	}
+	for _, refspec := range refspecs {
+		key := refspec.String()
+		if _, ok := want[key]; !ok {
+			t.Fatalf("unexpected refspec %q", key)
+		}
+		want[key] = true
+	}
+	for refspec, found := range want {
+		if !found {
+			t.Errorf("missing refspec %q", refspec)
+		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -452,20 +452,24 @@ type GithubDestination struct {
 }
 
 // GetHost TODO.
-func GetHost(url string) string {
-	if strings.Contains(url, "http://") {
-		url = strings.Split(url, "http://")[1]
+func GetHost(rawURL string) string {
+	if endpoint, err := transport.NewEndpoint(rawURL); err == nil && endpoint.Host != "" {
+		return endpoint.Host
 	}
 
-	if strings.Contains(url, "https://") {
-		url = strings.Split(url, "https://")[1]
+	if strings.Contains(rawURL, "http://") {
+		rawURL = strings.Split(rawURL, "http://")[1]
 	}
 
-	if strings.Contains(url, "/") {
-		url = strings.Split(url, "/")[0]
+	if strings.Contains(rawURL, "https://") {
+		rawURL = strings.Split(rawURL, "https://")[1]
 	}
 
-	return url
+	if strings.Contains(rawURL, "/") {
+		rawURL = strings.Split(rawURL, "/")[0]
+	}
+
+	return rawURL
 }
 
 // GetValues TODO.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -223,9 +223,12 @@ func TestGetHost(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
-		"https://example.com/org/repo": "example.com",
-		"http://example.com/org/repo":  "example.com",
-		"example.com/org/repo":         "example.com",
+		"https://example.com/org/repo":                           "example.com",
+		"http://example.com/org/repo":                            "example.com",
+		"ssh://alice%40example.com@git.example.com/org/repo.git": "git.example.com",
+		"ssh://git@example.com:2222/org/repo.git":                "example.com",
+		"git@example.com:org/repo.git":                           "example.com",
+		"example.com/org/repo":                                   "example.com",
 	}
 
 	for input, want := range tests {

--- a/whatever/whatever.go
+++ b/whatever/whatever.go
@@ -1,12 +1,34 @@
 package whatever
 
 import (
-	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/cooperspencer/gickup/types"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/rs/zerolog/log"
 )
+
+func getRepoNameAndHost(rawURL string) (string, string) {
+	endpoint, err := transport.NewEndpoint(rawURL)
+	if err == nil {
+		if endpoint.Protocol == "file" {
+			name := filepath.Base(filepath.Clean(endpoint.Path))
+			return strings.TrimSuffix(name, ".git"), "local"
+		}
+
+		repoPath := endpoint.Path
+		if index := strings.IndexAny(repoPath, "?#"); index >= 0 {
+			repoPath = repoPath[:index]
+		}
+		name := path.Base(strings.TrimRight(repoPath, "/"))
+		return strings.TrimSuffix(name, ".git"), endpoint.Host
+	}
+
+	name := filepath.Base(filepath.Clean(rawURL))
+	return strings.TrimSuffix(name, ".git"), "local"
+}
 
 // Get TODO.
 func Get(conf *types.Conf) ([]types.Repo, bool) {
@@ -22,9 +44,9 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 				log.Error().
 					Str("stage", "whatever").
 					Msg("no url configured")
+				continue
 			}
 
-			hoster := "local"
 			if repo.User == "" {
 				if repo.Username != "" {
 					repo.User = repo.Username
@@ -32,18 +54,7 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 					repo.User = "git"
 				}
 			}
-			if _, err := os.Stat(repo.URL); os.IsNotExist(err) {
-				hoster = types.GetHost(repo.URL)
-			}
-
-			separator := "/"
-			if hoster == "local" {
-				separator = string(os.PathSeparator)
-			}
-			name := repo.URL[strings.LastIndex(repo.URL, separator)+1:]
-			if strings.HasSuffix(name, ".git") {
-				name = name[:strings.LastIndex(name, ".git")]
-			}
+			name, hoster := getRepoNameAndHost(repo.URL)
 
 			repos = append(repos, types.Repo{
 				Name:   name,

--- a/whatever/whatever_test.go
+++ b/whatever/whatever_test.go
@@ -32,6 +32,54 @@ func TestGetBuildsRemoteRepo(t *testing.T) {
 	}
 }
 
+func TestGetBuildsSSHRemoteRepo(t *testing.T) {
+	t.Parallel()
+
+	conf := &types.Conf{
+		Source: types.Source{
+			Any: []types.GenRepo{{URL: "ssh://alice%40example.com@git.example.com/org/repo.git"}},
+		},
+	}
+
+	repos, ran := Get(conf)
+	if !ran {
+		t.Fatal("expected adapter to run")
+	}
+
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+
+	repo := repos[0]
+	if repo.Name != "repo" || repo.Hoster != "git.example.com" || repo.Owner != "git" {
+		t.Fatalf("unexpected repo: %#v", repo)
+	}
+}
+
+func TestGetBuildsSCPRemoteRepo(t *testing.T) {
+	t.Parallel()
+
+	conf := &types.Conf{
+		Source: types.Source{
+			Any: []types.GenRepo{{URL: "git@git.example.com:org/repo.git"}},
+		},
+	}
+
+	repos, ran := Get(conf)
+	if !ran {
+		t.Fatal("expected adapter to run")
+	}
+
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+
+	repo := repos[0]
+	if repo.Name != "repo" || repo.Hoster != "git.example.com" || repo.Owner != "git" {
+		t.Fatalf("unexpected repo: %#v", repo)
+	}
+}
+
 func TestGetBuildsLocalRepo(t *testing.T) {
 	t.Parallel()
 
@@ -58,5 +106,23 @@ func TestGetBuildsLocalRepo(t *testing.T) {
 	repo := repos[0]
 	if repo.Name != "repo" || repo.Hoster != "local" || repo.Owner != "alice" {
 		t.Fatalf("unexpected repo: %#v", repo)
+	}
+}
+
+func TestGetSkipsMissingURL(t *testing.T) {
+	t.Parallel()
+
+	conf := &types.Conf{
+		Source: types.Source{
+			Any: []types.GenRepo{{}},
+		},
+	}
+
+	repos, ran := Get(conf)
+	if !ran {
+		t.Fatal("expected adapter to run")
+	}
+	if len(repos) != 0 {
+		t.Fatalf("expected no repositories, got %d", len(repos))
 	}
 }


### PR DESCRIPTION
- Honor `destination.gitlab[].visibility.repositories` in both GitLab project-creation paths.
  - `private` and `public` explicitly override source visibility.
  - Empty or `source` visibility continues to follow the source repository.
- Parse `source.any` URLs with go-git's endpoint parser.
  - Correctly handle HTTP(S), SSH, SCP-style, and local repository paths.
  - Avoid treating SSH URLs as local Windows paths.
  - Derive valid repository names and hostnames from encoded SSH URLs.
  - Skip entries with a missing URL.
- Improve shared hostname extraction for SSH and SCP-style repository URLs.
- Push additional branches and tags individually after the default branch.
  - Exclude remote-tracking references.
  - Allow valid refs to continue when a destination hook rejects another ref.
  - Aggregate push errors so the backup run still reports partial failures.