### PR TITLE
Fix GitHub App authentication for LFS-backed local mirrors

### DIFF
--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -2,12 +2,30 @@ package gitcmd
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 )
+
+type Auth struct {
+	Username string
+	Password string
+}
+
+func (a *Auth) Env() []string {
+	if a == nil || (a.Username == "" && a.Password == "") {
+		return nil
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", a.Username, a.Password)))
+	return []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=http.extraHeader",
+		fmt.Sprintf("GIT_CONFIG_VALUE_0=Authorization: Basic %s", encoded),
+	}
+}
 
 type GitCmd struct {
 	CMD string
@@ -23,55 +41,64 @@ func New() (GitCmd, error) {
 	return GitCmd{CMD: "git"}, nil
 }
 
-func (g GitCmd) Clone(url, reponame string, bare bool, mirror bool) error {
-	cmd := exec.CommandContext(context.Background(), g.CMD, "clone", url, reponame)
+func (g GitCmd) Command(ctx context.Context, auth *Auth, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, g.CMD, args...)
+	if authEnv := auth.Env(); len(authEnv) > 0 {
+		cmd.Env = append(os.Environ(), authEnv...)
+	}
+	return cmd
+}
+
+func (g GitCmd) Clone(url, reponame string, bare bool, mirror bool, auth *Auth) error {
+	args := []string{"clone", url, reponame}
 	if bare {
-		cmd.Args = append(cmd.Args, "--bare")
+		args = append(args, "--bare")
 	}
 	if mirror {
-		cmd.Args = append(cmd.Args, "--mirror")
+		args = append(args, "--mirror")
 	}
+	cmd := g.Command(context.Background(), auth, args...)
 	return cmd.Run()
 }
 
-func (g GitCmd) Pull(bare bool, mirror bool, repopath string) error {
+func (g GitCmd) Pull(bare bool, mirror bool, repopath string, auth *Auth) error {
 	var args []string
 	if bare || mirror {
 		args = []string{"-C", repopath, "fetch", "--all"}
 	} else {
 		args = []string{"-C", repopath, "pull", "--all"}
 	}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), auth, args...)
 	return cmd.Run()
 }
 
-func (g GitCmd) Fetch(path string) error {
+func (g GitCmd) Fetch(path string, auth *Auth) error {
 	_, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
 	args := []string{"-C", path, "fetch", "--all", "--tags"}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), auth, args...)
 	return cmd.Run()
 }
 
-func (g GitCmd) LFSFetch(path string) error {
+func (g GitCmd) LFSFetch(path string, auth *Auth) error {
 	_, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
 	args := []string{"-C", path, "lfs", "fetch", "--all"}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), auth, args...)
 	return cmd.Run()
 }
 
-func (g GitCmd) MirrorPull(path string) error {
+func (g GitCmd) MirrorPull(path string, auth *Auth) error {
 	_, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
 	args := []string{"-C", path, "pull", "--all", "--tags"}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), auth, args...)
 	return cmd.Run()
 }
 
@@ -81,18 +108,18 @@ func (g GitCmd) NewRemote(name, url, path string) error {
 		return err
 	}
 	args := []string{"-C", path, "remote", "add", name, url}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), nil, args...)
 
 	return cmd.Run()
 }
 
-func (g GitCmd) Push(path, remote string) error {
+func (g GitCmd) Push(path, remote string, auth *Auth) error {
 	_, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
 	args := []string{"-C", path, "push", "--all", remote}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), auth, args...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -111,7 +138,7 @@ func (g GitCmd) Checkout(path, branch string) error {
 		return err
 	}
 	args := []string{"checkout", branch}
-	cmd := exec.CommandContext(context.Background(), g.CMD, args...)
+	cmd := g.Command(context.Background(), nil, args...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -125,10 +152,21 @@ func (g GitCmd) Checkout(path, branch string) error {
 }
 
 func (g GitCmd) SSHPush(path, remote, key string) error {
-	err := os.Setenv("GIT_SSH_COMMAND", fmt.Sprintf("ssh -i %s", key))
+	_, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
+	args := []string{"-C", path, "push", "--all", remote}
+	cmd := g.Command(context.Background(), nil, args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("GIT_SSH_COMMAND=ssh -i %s", key))
 
-	return g.Push(path, remote)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("%s", strings.TrimSuffix(string(output), "\n"))
+		}
+	}
+
+	return err
 }

--- a/gitcmd/gitcmd_test.go
+++ b/gitcmd/gitcmd_test.go
@@ -1,0 +1,282 @@
+package gitcmd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAuth_Env_Nil(t *testing.T) {
+	t.Parallel()
+
+	var auth *Auth
+	if got := auth.Env(); got != nil {
+		t.Fatalf("expected nil env for nil Auth, got %v", got)
+	}
+}
+
+func TestAuth_Env_Empty(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{Username: "", Password: ""}
+	if got := auth.Env(); got != nil {
+		t.Fatalf("expected nil env for empty Auth, got %v", got)
+	}
+}
+
+func TestAuth_Env_GitHubApp(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{
+		Username: "x-access-token",
+		Password: "ghs_secretinstallationtoken123",
+	}
+
+	env := auth.Env()
+	expectedHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:ghs_secretinstallationtoken123"))
+	expectedEnv := []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=http.extraHeader",
+		"GIT_CONFIG_VALUE_0=" + expectedHeader,
+	}
+
+	if !reflect.DeepEqual(env, expectedEnv) {
+		t.Fatalf("auth.Env() = %v, want %v", env, expectedEnv)
+	}
+}
+
+func TestAuth_Env_UserPassword(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{
+		Username: "octocat",
+		Password: "secretpassword456",
+	}
+
+	env := auth.Env()
+	expectedHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("octocat:secretpassword456"))
+	expectedEnv := []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=http.extraHeader",
+		"GIT_CONFIG_VALUE_0=" + expectedHeader,
+	}
+
+	if !reflect.DeepEqual(env, expectedEnv) {
+		t.Fatalf("auth.Env() = %v, want %v", env, expectedEnv)
+	}
+}
+
+func TestGitCmd_Command_WithoutAuth(t *testing.T) {
+	t.Parallel()
+
+	g := GitCmd{CMD: "git"}
+	cmd := g.Command(context.Background(), nil, "status")
+
+	if cmd.Path != "git" && !strings.HasSuffix(cmd.Path, "git") && !strings.HasSuffix(cmd.Path, "git.exe") {
+		t.Errorf("cmd.Path = %q, want 'git'", cmd.Path)
+	}
+	if !reflect.DeepEqual(cmd.Args, []string{"git", "status"}) {
+		t.Errorf("cmd.Args = %v, want ['git', 'status']", cmd.Args)
+	}
+	if cmd.Env != nil {
+		t.Errorf("cmd.Env for nil Auth = %v, want nil", cmd.Env)
+	}
+}
+
+func TestGitCmd_Command_WithAuth(t *testing.T) {
+	t.Parallel()
+
+	g := GitCmd{CMD: "git"}
+	auth := &Auth{Username: "x-access-token", Password: "test-token"}
+	cmd := g.Command(context.Background(), auth, "clone", "https://github.com/owner/repo.git", "/tmp/repo")
+
+	if cmd.Env == nil {
+		t.Fatal("cmd.Env is nil, want environment variables with auth config")
+	}
+
+	hasConfigCount := false
+	hasConfigKey := false
+	hasConfigValue := false
+
+	expectedValue := fmt.Sprintf("GIT_CONFIG_VALUE_0=Authorization: Basic %s",
+		base64.StdEncoding.EncodeToString([]byte("x-access-token:test-token")))
+
+	for _, e := range cmd.Env {
+		if e == "GIT_CONFIG_COUNT=1" {
+			hasConfigCount = true
+		}
+		if e == "GIT_CONFIG_KEY_0=http.extraHeader" {
+			hasConfigKey = true
+		}
+		if e == expectedValue {
+			hasConfigValue = true
+		}
+	}
+
+	if !hasConfigCount || !hasConfigKey || !hasConfigValue {
+		t.Errorf("cmd.Env missing required GIT_CONFIG variables, env = %v", cmd.Env)
+	}
+
+	// Verify the URL in cmd.Args does NOT contain token
+	for _, arg := range cmd.Args {
+		if strings.Contains(arg, "test-token") {
+			t.Errorf("token leaked into command arguments: %q", arg)
+		}
+	}
+}
+
+func TestGitCmd_CloneCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		reponame string
+		bare     bool
+		mirror   bool
+		auth     *Auth
+		wantArgs []string
+		wantAuth bool
+	}{
+		{
+			name:     "regular clone without auth",
+			url:      "https://github.com/owner/repo.git",
+			reponame: "/tmp/repo",
+			bare:     false,
+			mirror:   false,
+			auth:     nil,
+			wantArgs: []string{"git", "clone", "https://github.com/owner/repo.git", "/tmp/repo"},
+			wantAuth: false,
+		},
+		{
+			name:     "bare clone with token",
+			url:      "https://github.com/owner/repo.git",
+			reponame: "/tmp/repo.git",
+			bare:     true,
+			mirror:   false,
+			auth:     &Auth{Username: "x-access-token", Password: "my-token"},
+			wantArgs: []string{"git", "clone", "https://github.com/owner/repo.git", "/tmp/repo.git", "--bare"},
+			wantAuth: true,
+		},
+		{
+			name:     "mirror clone with user/pass",
+			url:      "https://github.com/owner/repo.git",
+			reponame: "/tmp/repo.git",
+			bare:     true,
+			mirror:   true,
+			auth:     &Auth{Username: "user", Password: "pass"},
+			wantArgs: []string{"git", "clone", "https://github.com/owner/repo.git", "/tmp/repo.git", "--bare", "--mirror"},
+			wantAuth: true,
+		},
+	}
+
+	g := GitCmd{CMD: "git"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{"clone", tt.url, tt.reponame}
+			if tt.bare {
+				args = append(args, "--bare")
+			}
+			if tt.mirror {
+				args = append(args, "--mirror")
+			}
+			cmd := g.Command(context.Background(), tt.auth, args...)
+
+			if !reflect.DeepEqual(cmd.Args, tt.wantArgs) {
+				t.Errorf("cmd.Args = %v, want %v", cmd.Args, tt.wantArgs)
+			}
+
+			if tt.wantAuth && cmd.Env == nil {
+				t.Error("cmd.Env is nil, want auth environment")
+			}
+			if !tt.wantAuth && cmd.Env != nil {
+				t.Errorf("cmd.Env = %v, want nil", cmd.Env)
+			}
+
+			for _, arg := range cmd.Args {
+				if strings.Contains(arg, "@") {
+					t.Errorf("URL in arguments contains credentials: %s", arg)
+				}
+			}
+		})
+	}
+}
+
+func TestGitCmd_PullCommand(t *testing.T) {
+	t.Parallel()
+
+	g := GitCmd{CMD: "git"}
+	auth := &Auth{Username: "x-access-token", Password: "test-token"}
+
+	// Bare/mirror fetch
+	bareArgs := []string{"-C", "/tmp/repo.git", "fetch", "--all"}
+	bareCmd := g.Command(context.Background(), auth, bareArgs...)
+	wantBareArgs := []string{"git", "-C", "/tmp/repo.git", "fetch", "--all"}
+	if !reflect.DeepEqual(bareCmd.Args, wantBareArgs) {
+		t.Errorf("bareCmd.Args = %v, want %v", bareCmd.Args, wantBareArgs)
+	}
+	if bareCmd.Env == nil {
+		t.Error("bareCmd.Env is nil, want auth environment")
+	}
+
+	// Non-bare pull
+	pullArgs := []string{"-C", "/tmp/repo", "pull", "--all"}
+	pullCmd := g.Command(context.Background(), auth, pullArgs...)
+	wantPullArgs := []string{"git", "-C", "/tmp/repo", "pull", "--all"}
+	if !reflect.DeepEqual(pullCmd.Args, wantPullArgs) {
+		t.Errorf("pullCmd.Args = %v, want %v", pullCmd.Args, wantPullArgs)
+	}
+	if pullCmd.Env == nil {
+		t.Error("pullCmd.Env is nil, want auth environment")
+	}
+}
+
+func TestGitCmd_LFSFetchCommand(t *testing.T) {
+	t.Parallel()
+
+	g := GitCmd{CMD: "git"}
+	auth := &Auth{Username: "x-access-token", Password: "test-token"}
+
+	lfsArgs := []string{"-C", "/tmp/repo.git", "lfs", "fetch", "--all"}
+	cmd := g.Command(context.Background(), auth, lfsArgs...)
+	wantArgs := []string{"git", "-C", "/tmp/repo.git", "lfs", "fetch", "--all"}
+
+	if !reflect.DeepEqual(cmd.Args, wantArgs) {
+		t.Errorf("cmd.Args = %v, want %v", cmd.Args, wantArgs)
+	}
+	if cmd.Env == nil {
+		t.Fatal("cmd.Env is nil, want auth environment for LFS fetch")
+	}
+
+	foundExtraHeader := false
+	for _, e := range cmd.Env {
+		if e == "GIT_CONFIG_KEY_0=http.extraHeader" {
+			foundExtraHeader = true
+		}
+	}
+	if !foundExtraHeader {
+		t.Error("cmd.Env does not contain GIT_CONFIG_KEY_0=http.extraHeader for LFS fetch")
+	}
+}
+
+func TestGitCmd_LocalCommandsHaveNoAuth(t *testing.T) {
+	t.Parallel()
+
+	g := GitCmd{CMD: "git"}
+
+	// Checkout should have no auth
+	checkoutCmd := g.Command(context.Background(), nil, "checkout", "main")
+	if checkoutCmd.Env != nil {
+		t.Errorf("checkoutCmd.Env = %v, want nil", checkoutCmd.Env)
+	}
+
+	// NewRemote should have no auth
+	remoteCmd := g.Command(context.Background(), nil, "-C", "/tmp/repo", "remote", "add", "origin", "https://github.com/owner/repo.git")
+	if remoteCmd.Env != nil {
+		t.Errorf("remoteCmd.Env = %v, want nil", remoteCmd.Env)
+	}
+}

--- a/gitcmd/gitcmd_test.go
+++ b/gitcmd/gitcmd_test.go
@@ -32,11 +32,11 @@ func TestAuth_Env_GitHubApp(t *testing.T) {
 
 	auth := &Auth{
 		Username: "x-access-token",
-		Password: "ghs_secretinstallationtoken123",
+		Password: "test-token",
 	}
 
 	env := auth.Env()
-	expectedHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:ghs_secretinstallationtoken123"))
+	expectedHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:test-token"))
 	expectedEnv := []string{
 		"GIT_CONFIG_COUNT=1",
 		"GIT_CONFIG_KEY_0=http.extraHeader",
@@ -177,6 +177,8 @@ func TestGitCmd_CloneCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			args := []string{"clone", tt.url, tt.reponame}
 			if tt.bare {
 				args = append(args, "--bare")

--- a/local/local.go
+++ b/local/local.go
@@ -51,6 +51,16 @@ func tokenAuth(repo types.Repo) *http.BasicAuth {
 	}
 }
 
+func toGitCmdAuth(auth transport.AuthMethod) *gitcmd.Auth {
+	if basicAuth, ok := auth.(*http.BasicAuth); ok && basicAuth != nil {
+		return &gitcmd.Auth{
+			Username: basicAuth.Username,
+			Password: basicAuth.Password,
+		}
+	}
+	return nil
+}
+
 // Locally TODO.
 func Locally(repo types.Repo, l types.Local, dry bool) bool {
 	sub = logger.CreateSubLogger("stage", "locally", "path", l.Path)
@@ -187,7 +197,7 @@ func Locally(repo types.Repo, l types.Local, dry bool) bool {
 				sub.Info().
 					Msgf("opening %s locally", types.Green(repo.Name))
 
-				err := updateRepository(repo.Name, auth, dry, l)
+				err := updateRepository(repo, auth, dry, l)
 				if err != nil {
 					switch {
 					case errors.Is(err, git.NoErrAlreadyUpToDate):
@@ -331,32 +341,63 @@ func pruneOldBackups(parentdir string, repoName string, l types.Local) error {
 	return nil
 }
 
-func updateRepository(reponame string, auth transport.AuthMethod, dry bool, l types.Local) error {
-	r, err := git.PlainOpen(filepath.Join(l.Path, reponame))
+func sanitizeRemote(r *git.Repository, cleanURL string) error {
+	if cleanURL == "" {
+		return nil
+	}
+	cfg, err := r.Config()
+	if err != nil {
+		return err
+	}
+	rem, ok := cfg.Remotes["origin"]
+	if !ok || rem == nil {
+		return nil
+	}
+	changed := false
+	for i, u := range rem.URLs {
+		if (strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")) && strings.Contains(u, "@") {
+			rem.URLs[i] = cleanURL
+			changed = true
+		}
+	}
+	if changed {
+		return r.SetConfig(cfg)
+	}
+	return nil
+}
+
+func updateRepository(repo types.Repo, auth transport.AuthMethod, dry bool, l types.Local) error {
+	r, err := git.PlainOpen(filepath.Join(l.Path, repo.Name))
 	if err != nil {
 		return err
 	}
 
 	if !dry {
 		if l.LFS {
-			_, err = os.Stat(filepath.Join(l.Path, reponame))
+			_, err = os.Stat(filepath.Join(l.Path, repo.Name))
 			if err != nil {
 				return err
 			}
 
-			sub.Info().
-				Msgf("pulling %s", types.Green(reponame))
+			if !repo.Origin.SSH && repo.URL != "" {
+				if err := sanitizeRemote(r, repo.URL); err != nil {
+					sub.Warn().Str("repo", repo.Name).Msgf("could not sanitize remote: %s", err)
+				}
+			}
 
-			err = gitc.Pull(l.Bare, l.Mirror, filepath.Join(l.Path, reponame))
+			sub.Info().
+				Msgf("pulling %s", types.Green(repo.Name))
+
+			err = gitc.Pull(l.Bare, l.Mirror, filepath.Join(l.Path, repo.Name), toGitCmdAuth(auth))
 			if err != nil {
 				return err
 			}
 
 			if l.Bare || l.Mirror {
 				sub.Info().
-					Msgf("fetching lfs files for %s", types.Green(reponame))
+					Msgf("fetching lfs files for %s", types.Green(repo.Name))
 
-				err = gitc.LFSFetch(filepath.Join(l.Path, reponame))
+				err = gitc.LFSFetch(filepath.Join(l.Path, repo.Name), toGitCmdAuth(auth))
 				if err != nil {
 					return err
 				}
@@ -368,7 +409,7 @@ func updateRepository(reponame string, auth transport.AuthMethod, dry bool, l ty
 				return err
 			}
 			sub.Info().
-				Msgf("pulling %s", types.Green(reponame))
+				Msgf("pulling %s", types.Green(repo.Name))
 			if !l.Bare && !l.Mirror {
 				w, worktreeErr := r.Worktree()
 				if worktreeErr != nil && !errors.Is(worktreeErr, git.NoErrAlreadyUpToDate) {
@@ -428,25 +469,7 @@ func cloneRepository(repo types.Repo, auth transport.AuthMethod, dry bool, l typ
 	}
 
 	if l.LFS {
-		if repo.Token != "" {
-			if strings.HasPrefix(url, "http://") {
-				url = strings.ReplaceAll(url, "http://", fmt.Sprintf("http://xyz:%s@", repo.Token))
-			}
-
-			if strings.HasPrefix(url, "https://") {
-				url = strings.ReplaceAll(url, "https://", fmt.Sprintf("https://xyz:%s@", repo.Token))
-			}
-		} else if repo.Origin.Username != "" && repo.Origin.Password != "" {
-			if strings.HasPrefix(url, "http://") {
-				url = strings.ReplaceAll(url, "http://", fmt.Sprintf("http://%s:%s@", repo.Origin.Username, repo.Origin.Password))
-			}
-
-			if strings.HasPrefix(url, "https://") {
-				url = strings.ReplaceAll(url, "https://", fmt.Sprintf("https://%s:%s@", repo.Origin.Username, repo.Origin.Password))
-			}
-		}
-
-		err = gitc.Clone(url, filepath.Join(l.Path, repo.Name), l.Bare, l.Mirror)
+		err = gitc.Clone(url, filepath.Join(l.Path, repo.Name), l.Bare, l.Mirror, toGitCmdAuth(auth))
 		if err != nil {
 			return err
 		}
@@ -455,7 +478,7 @@ func cloneRepository(repo types.Repo, auth transport.AuthMethod, dry bool, l typ
 			sub.Info().
 				Msgf("fetching lfs files for %s", types.Green(repo.Name))
 
-			err = gitc.LFSFetch(filepath.Join(l.Path, repo.Name))
+			err = gitc.LFSFetch(filepath.Join(l.Path, repo.Name), toGitCmdAuth(auth))
 			if err != nil {
 				return err
 			}
@@ -538,6 +561,11 @@ func tempCloneBase(repo types.Repo, tempdir string, isBare bool) (*git.Repositor
 	var auth transport.AuthMethod
 	if repo.Token != "" {
 		auth = tokenAuth(repo)
+	} else if repo.Origin.Username != "" && repo.Origin.Password != "" {
+		auth = &http.BasicAuth{
+			Username: repo.Origin.Username,
+			Password: repo.Origin.Password,
+		}
 	}
 	if repo.Origin.LFS {
 		g, err := gitcmd.New()
@@ -546,15 +574,7 @@ func tempCloneBase(repo types.Repo, tempdir string, isBare bool) (*git.Repositor
 		}
 		gitc = g
 
-		if strings.HasPrefix(repo.URL, "http://") {
-			repo.URL = strings.ReplaceAll(repo.URL, "http://", fmt.Sprintf("http://xyz:%s@", repo.Token))
-		}
-
-		if strings.HasPrefix(repo.URL, "https://") {
-			repo.URL = strings.ReplaceAll(repo.URL, "https://", fmt.Sprintf("https://xyz:%s@", repo.Token))
-		}
-
-		err = gitc.Clone(repo.URL, tempdir, isBare, false)
+		err = gitc.Clone(repo.URL, tempdir, isBare, false, toGitCmdAuth(auth))
 		if err != nil {
 			return nil, err
 		}
@@ -600,7 +620,7 @@ func tempCloneBase(repo types.Repo, tempdir string, isBare bool) (*git.Repositor
 			return nil, err
 		}
 
-		err = gitc.MirrorPull(tempdir)
+		err = gitc.MirrorPull(tempdir, toGitCmdAuth(auth))
 		if err != nil {
 			return nil, err
 		}
@@ -691,20 +711,12 @@ func CreateRemotePush(repo *git.Repository, destination types.GenRepo, url strin
 				return err
 			}
 		} else {
-			if strings.HasPrefix(url, "http://") {
-				url = strings.ReplaceAll(url, "http://", fmt.Sprintf("http://xyz:%s@", token))
-			}
-
-			if strings.HasPrefix(url, "https://") {
-				url = strings.ReplaceAll(url, "https://", fmt.Sprintf("https://xyz:%s@", token))
-			}
-
 			err = gitc.NewRemote(remote, url, worktree.Filesystem.Root())
 			if err != nil {
 				return err
 			}
 
-			err = gitc.Push(worktree.Filesystem.Root(), remote)
+			err = gitc.Push(worktree.Filesystem.Root(), remote, toGitCmdAuth(auth))
 			if err != nil {
 				return err
 			}

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/cooperspencer/gickup/types"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 )
 
 func runPrune(t *testing.T, backups []string, keep int) []string {
@@ -178,5 +182,190 @@ func TestTokenAuth_WithTokenUser(t *testing.T) {
 	}
 	if got.Password != "mytoken" {
 		t.Errorf("Password = %q, want %q", got.Password, "mytoken")
+	}
+}
+
+func TestToGitCmdAuth_Nil(t *testing.T) {
+	t.Parallel()
+
+	if got := toGitCmdAuth(nil); got != nil {
+		t.Fatalf("toGitCmdAuth(nil) = %v, want nil", got)
+	}
+}
+
+func TestToGitCmdAuth_FromTokenAuth_GitHubApp(t *testing.T) {
+	t.Parallel()
+
+	repo := types.Repo{
+		Token:       "ghs_testtoken123",
+		NoTokenUser: true,
+	}
+	auth := tokenAuth(repo)
+	gitAuth := toGitCmdAuth(auth)
+	if gitAuth == nil {
+		t.Fatal("toGitCmdAuth returned nil, want *gitcmd.Auth")
+	}
+	if gitAuth.Username != "x-access-token" {
+		t.Errorf("Username = %q, want %q", gitAuth.Username, "x-access-token")
+	}
+	if gitAuth.Password != "ghs_testtoken123" {
+		t.Errorf("Password = %q, want %q", gitAuth.Password, "ghs_testtoken123")
+	}
+
+	env := gitAuth.Env()
+	if len(env) != 3 {
+		t.Fatalf("expected 3 env vars, got %d: %v", len(env), env)
+	}
+	if env[0] != "GIT_CONFIG_COUNT=1" || env[1] != "GIT_CONFIG_KEY_0=http.extraHeader" {
+		t.Errorf("unexpected env vars: %v", env)
+	}
+	if !strings.HasPrefix(env[2], "GIT_CONFIG_VALUE_0=Authorization: Basic ") {
+		t.Errorf("unexpected GIT_CONFIG_VALUE_0: %s", env[2])
+	}
+}
+
+func TestToGitCmdAuth_FromUsernamePassword(t *testing.T) {
+	t.Parallel()
+
+	auth := &http.BasicAuth{
+		Username: "myuser",
+		Password: "mypassword",
+	}
+	gitAuth := toGitCmdAuth(auth)
+	if gitAuth == nil {
+		t.Fatal("toGitCmdAuth returned nil, want *gitcmd.Auth")
+	}
+	if gitAuth.Username != "myuser" {
+		t.Errorf("Username = %q, want %q", gitAuth.Username, "myuser")
+	}
+	if gitAuth.Password != "mypassword" {
+		t.Errorf("Password = %q, want %q", gitAuth.Password, "mypassword")
+	}
+}
+
+func TestToGitCmdAuth_SSHAuth(t *testing.T) {
+	t.Parallel()
+
+	auth := &ssh.PublicKeys{}
+	if got := toGitCmdAuth(auth); got != nil {
+		t.Fatalf("toGitCmdAuth(ssh) = %v, want nil", got)
+	}
+}
+
+func TestSanitizeRemote_RewritesCredentialURL(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, true)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://xyz:expired-token-123@github.com/owner/repo.git"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create remote: %v", err)
+	}
+
+	err = sanitizeRemote(r, "https://github.com/owner/repo.git")
+	if err != nil {
+		t.Fatalf("sanitizeRemote returned error: %v", err)
+	}
+
+	// Reopen the repository from disk to verify persistence
+	reopened, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("failed to reopen repo: %v", err)
+	}
+
+	cfg, err := reopened.Config()
+	if err != nil {
+		t.Fatalf("failed to get config: %v", err)
+	}
+
+	rem, ok := cfg.Remotes["origin"]
+	if !ok {
+		t.Fatal("remote origin not found")
+	}
+
+	wantURLs := []string{"https://github.com/owner/repo.git"}
+	if !reflect.DeepEqual(rem.URLs, wantURLs) {
+		t.Errorf("remote URLs = %v, want %v", rem.URLs, wantURLs)
+	}
+
+	for _, u := range rem.URLs {
+		if strings.Contains(u, "expired-token-123") || strings.Contains(u, "xyz:") || strings.Contains(u, "@") {
+			t.Errorf("token or credentials leaked in remote URL: %s", u)
+		}
+	}
+}
+
+func TestSanitizeRemote_PreservesSSH(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, true)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:owner/repo.git"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create remote: %v", err)
+	}
+
+	err = sanitizeRemote(r, "https://github.com/owner/repo.git")
+	if err != nil {
+		t.Fatalf("sanitizeRemote returned error: %v", err)
+	}
+
+	cfg, err := r.Config()
+	if err != nil {
+		t.Fatalf("failed to get config: %v", err)
+	}
+
+	rem := cfg.Remotes["origin"]
+	wantURLs := []string{"git@github.com:owner/repo.git"}
+	if !reflect.DeepEqual(rem.URLs, wantURLs) {
+		t.Errorf("SSH remote URLs = %v, want %v", rem.URLs, wantURLs)
+	}
+}
+
+func TestSanitizeRemote_PreservesCleanURL(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, true)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/owner/repo.git"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create remote: %v", err)
+	}
+
+	err = sanitizeRemote(r, "https://github.com/owner/repo.git")
+	if err != nil {
+		t.Fatalf("sanitizeRemote returned error: %v", err)
+	}
+
+	cfg, err := r.Config()
+	if err != nil {
+		t.Fatalf("failed to get config: %v", err)
+	}
+
+	rem := cfg.Remotes["origin"]
+	wantURLs := []string{"https://github.com/owner/repo.git"}
+	if !reflect.DeepEqual(rem.URLs, wantURLs) {
+		t.Errorf("clean remote URLs = %v, want %v", rem.URLs, wantURLs)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes local mirror updates when GitHub App authentication is used together with `lfs: true`.

GitHub App installation tokens are short-lived. Previously, the LFS local clone path embedded the current token in the HTTPS clone URL, so that credential was persisted in `remote.origin.url`. Later backup runs then reused the expired credential through `git fetch` / `git lfs fetch`, causing private repositories to fail with `exit status 128` while public repositories could continue to update.

## Changes

- pass HTTP authentication to Git/Git LFS transiently via process environment instead of embedding credentials in repository URLs
- use fresh source authentication for local mirror pull/fetch operations
- sanitize existing local mirrors whose `origin` still contains credential-bearing HTTPS URLs
- avoid persisting credentials in temporary LFS clone paths as well
- keep SSH command configuration process-local instead of modifying the parent process environment
- add regression tests for transient auth and migration of existing remotes

## Validation

- `go test ./...` passes in the project Docker/Go environment
- built the patched Docker image successfully
- tested on an existing Synology backup containing private GitHub App-authenticated mirrors created by the previous implementation
- private repositories that previously failed with `exit status 128` now complete pull + LFS fetch successfully
- the old credential-bearing `remote.origin.url` is migrated to the clean repository URL and remains credential-free after the run

Example migrated origin:

    https://github.com/owner/repository.git

instead of a URL containing the installation token.