### PR TITLE
Add Scoop to distribution packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ https://github.com/cooperspencer/gickup/discussions
 |Arch|[gickup](https://aur.archlinux.org/packages/gickup/)|[me](https://github.com/cooperspencer)|
 |Homebrew|[gickup](https://formulae.brew.sh/formula/gickup#default)||
 |Fedora|[gickup](https://copr.fedorainfracloud.org/coprs/frostyx/gickup/)|[FrostyX](https://github.com/FrostyX)|
+|Scoop|[gickup](https://scoop.sh/#/apps?q=gickup&id=493e856707843828b4491004edfb6ddedc4bd1e1)||
 
 ## Issues
 The mirroring to Gitlab doesn't work, or at least I can't test it properly because I have no access to a Gitlab EE instance.


### PR DESCRIPTION
As of https://github.com/ScoopInstaller/Main/pull/8380, [gickup](https://scoop.sh/#/apps?q=gickup&id=493e856707843828b4491004edfb6ddedc4bd1e1) is now available on Scoop.