### PR TITLE
Check the error when listing GitLab descendant groups

### DIFF
--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -221,6 +221,11 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 			subgroups, err := gitlab.ScanAndCollect(func(p gitlab.PaginationOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
 				return client.Groups.ListDescendantGroups(group.ID, &gitlab.ListDescendantGroupsOptions{}, p)
 			})
+			if err != nil {
+				sub.Error().
+					Msg(err.Error())
+				continue
+			}
 
 			for _, sub := range subgroups {
 				includeorgs[sub.FullPath] = true
@@ -238,6 +243,11 @@ func Get(conf *types.Conf) ([]types.Repo, bool) {
 			subgroups, err := gitlab.ScanAndCollect(func(p gitlab.PaginationOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
 				return client.Groups.ListDescendantGroups(group.ID, &gitlab.ListDescendantGroupsOptions{}, p)
 			})
+			if err != nil {
+				sub.Error().
+					Msg(err.Error())
+				continue
+			}
 
 			for _, sub := range subgroups {
 				excludeorgs[sub.FullPath] = true


### PR DESCRIPTION
Both `ScanAndCollect` calls in `gitlab.Get` discard their error:

```go
subgroups, err := gitlab.ScanAndCollect(func(p gitlab.PaginationOptionFunc) ([]*gitlab.Group, *gitlab.Response, error) {
    return client.Groups.ListDescendantGroups(group.ID, &gitlab.ListDescendantGroupsOptions{}, p)
})

for _, sub := range subgroups {
    includeorgs[sub.FullPath] = true
}
```

`ScanAndCollect` accumulates pages and returns what it has together with the error, so a failure part-way through pagination (rate limit, a group the token cannot read, a network blip) returns a short slice and a non-nil error. With the error dropped, the loop just adds fewer subgroups and execution continues as if the list were complete.

For the `IncludeOrgs` case at line 221 that is the harmful direction: `includeorgs` is what decides which repositories get mirrored, so missing subgroups means **those repositories are silently left out of the backup** and the run still reports success. The `ExcludeOrgs` case at line 238 fails the other way and mirrors more than intended.

The `GetGroup` call seven lines above each of these already handles its error by logging and continuing, so the added block is the same shape as the code directly around it rather than a new idiom.

staticcheck flags both as SA4006, since `err` is reassigned from the `GetGroup` call above and then never read.

Verified: `go build ./...` passes, `go test ./...` green, `gofmt -l` clean on the touched file, SA4006 gone under `GOOS=linux` and `GOOS=darwin`.